### PR TITLE
1.A: Generate ImageError for unknown Serial Numbers

### DIFF
--- a/src/api/db/models/Image.js
+++ b/src/api/db/models/Image.js
@@ -122,7 +122,11 @@ const generateImageModel = ({ user } = {}) => ({
             md.serialNumber = batch.overrideSerial;
             cameraId = batch.overrideSerial;
           }
+        }
 
+        if (!cameraId || cameraId === 'unknown') {
+          errors.push(new Error('Unknown Serial Number'));
+        } else if (md.batchId) {
           // create camera config if there isn't one yet
           await context.models.Project.createCameraConfig(projectId, cameraId);
         } else {


### PR DESCRIPTION
### Context

Reject all images w/ unknown SNs in the image-ingest lambda, and write those errors to the ImageError collection.