### PR TITLE
CreateImage Error Input

### DIFF
--- a/src/api/db/models/Image.js
+++ b/src/api/db/models/Image.js
@@ -95,7 +95,13 @@ export class ImageModel {
 
   static async createImage(input, context) {
     const successfulOps = [];
-    const errors = [];
+
+    const errors = (input.errors || []).filter((err) => {
+      return typeof err === 'string';
+    }).map((err) => {
+      return new Error(err);
+    });
+
     const md = sanitizeMetadata(input.md);
     let projectId = 'default_project';
     let cameraId = md.serialNumber; // this will be 'unknown' if there's no SN


### PR DESCRIPTION
### Context

The Animl-Ingest/Ingest-Image code needs the ability to send errors that it has detected in the Image Data Itself as the API does not directly handle this data and as such cannot throw an error before creating both an `ImageAttempt` and `Image` object.

This PR allows the submission of an optional `errors` key containing an array of String errors that will be mapped to errors objects, resulting in an `Image` record never being created.

Ref: https://github.com/tnc-ca-geo/animl-ingest/issues/60