### PR TITLE
Rm docker based lambda in favor of node lambda runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM public.ecr.aws/lambda/nodejs:18
-
-COPY . ${LAMBDA_TASK_ROOT}/
-
-RUN npm install

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,12 +19,6 @@ provider:
     STAGE: ${self:provider.stage}
     ACCOUNT: ${aws:accountId}
 
-  ecr:
-    images:
-      base:
-        path: .
-        platform: linux/amd64
-
   iam:
     role:
       statements:
@@ -123,9 +117,8 @@ provider:
 
 functions:
   graphql:
-    image:
-      name: base
-      command: src/api/handler.server
+    handler: src/api/handler.server
+    runtime: nodejs20.x
     events:
     - http:
         path: /
@@ -148,9 +141,8 @@ functions:
     memorySize: 3008
     timeout: 30
   inference:
-    image:
-      name: base
-      command: src/ml/handler.inference
+    handler: src/ml/handler.inference
+    runtime: nodejs20.x
     reservedConcurrency: 20
     events:
       - sqs:
@@ -162,15 +154,13 @@ functions:
           functionResponseType: ReportBatchItemFailures
     timeout: 120
   batchinference:
-    image:
-      name: base
-      command: src/ml/handler.inference
+    handler: src/ml/handler.inference
+    runtime: nodejs20.x
     reservedConcurrency: 8
     timeout: 120
   task:
-    image:
-      name: base
-      command: src/task/handler.handler
+    handler: src/task/handler.handler
+    runtime: nodejs20.x
     reservedConcurrency: 10
     events:
       - sqs:


### PR DESCRIPTION
I successfully deployed #176 once removing the Lambda Docker tooling. Given that @jue-henry is also working on some tooling that depends on the removal of the Lambda Docker, I believe it may be wise to get that done separately in hopes of minimizing merge conflicts.

> [!IMPORTANT]  
> A note regarding deploying this code: AWS can not change the type of a Lambda function from Docker-based to code-based. If you attempt to do a simple `sls deploy`, you will receive the following error:
> ```
> Error:
> UPDATE_FAILED: TaskLambdaFunction (AWS::Lambda::Function)
> Resource handler returned message: "Invalid request provided: Updating PackageType is not supported" (RequestToken: 3d99584b-c459-d51b-4d46-8e19b83cd139, HandlerErrorCode: InvalidRequest)
> ```
>
> Instead, you must deploy this change in two steps:
> 1. Rename the lambda resources (e.g. append `-tmp` to each function, so that `graphql:` becomes `graphql-tmp:`), deploy.
> 2. Revert rename of the lambda resources, deploy.
>
> This will delete and recreate the lambda functions.  It's a bit of a painful process but is necessary to get around this limitation.