### PR TITLE
Fixing Local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM public.ecr.aws/lambda/nodejs:18
-
-COPY . ${LAMBDA_TASK_ROOT}/
-
-RUN npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Lambda-based graphQL API for camera trap data management platform",
     "main": "src/handler.js",
     "scripts": {
-        "start": "serverless offline --noAuth",
+        "start": "AWS_PROFILE=animl serverless offline --noAuth",
         "deploy-dev": "sls deploy --stage dev",
         "deploy-prod": "sls deploy --stage prod",
         "seed-db": "AWS_PROFILE=animl REGION=us-west-2 node ./src/scripts/seedDb.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Lambda-based graphQL API for camera trap data management platform",
     "main": "src/handler.js",
     "scripts": {
-        "start": "serverless offline",
+        "start": "serverless offline --noAuth",
         "deploy-dev": "sls deploy --stage dev",
         "deploy-prod": "sls deploy --stage prod",
         "seed-db": "AWS_PROFILE=animl REGION=us-west-2 node ./src/scripts/seedDb.js",

--- a/serverless.yml
+++ b/serverless.yml
@@ -116,6 +116,7 @@ provider:
               - ''
               - - 'arn:aws:s3:::'
                 - 'animl-images-serving-${self:provider.stage}/*'
+                
   apiGateway:
     apiKeys:
       - name: animlApiKeyInternal-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -142,7 +142,7 @@ functions:
     memorySize: 3008
     timeout: 30
   inference:
-    handler: src/api/handler.server
+    handler: src/ml/handler.inference
     runtime: nodejs20.x
     reservedConcurrency: 20
     events:
@@ -155,12 +155,12 @@ functions:
           functionResponseType: ReportBatchItemFailures
     timeout: 120
   batchinference:
-    handler: src/api/handler.server
+    handler: src/ml/handler.inference
     runtime: nodejs20.x
     reservedConcurrency: 8
     timeout: 120
   task:
-    handler: src/api/handler.server
+    handler: src/task/handler.handler
     runtime: nodejs20.x
     reservedConcurrency: 10
     events:

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,12 +19,6 @@ provider:
     STAGE: ${self:provider.stage}
     ACCOUNT: ${aws:accountId}
 
-  ecr:
-    images:
-      base:
-        path: .
-        platform: linux/amd64
-
   iam:
     role:
       statements:
@@ -116,7 +110,7 @@ provider:
               - ''
               - - 'arn:aws:s3:::'
                 - 'animl-images-serving-${self:provider.stage}/*'
-                
+
   apiGateway:
     apiKeys:
       - name: animlApiKeyInternal-${self:provider.stage}
@@ -148,9 +142,8 @@ functions:
     memorySize: 3008
     timeout: 30
   inference:
-    image:
-      name: base
-      command: src/ml/handler.inference
+    handler: src/api/handler.server
+    runtime: nodejs20.x
     reservedConcurrency: 20
     events:
       - sqs:
@@ -162,15 +155,13 @@ functions:
           functionResponseType: ReportBatchItemFailures
     timeout: 120
   batchinference:
-    image:
-      name: base
-      command: src/ml/handler.inference
+    handler: src/api/handler.server
+    runtime: nodejs20.x
     reservedConcurrency: 8
     timeout: 120
   task:
-    image:
-      name: base
-      command: src/task/handler.handler
+    handler: src/api/handler.server
+    runtime: nodejs20.x
     reservedConcurrency: 10
     events:
       - sqs:

--- a/serverless.yml
+++ b/serverless.yml
@@ -123,9 +123,8 @@ provider:
 
 functions:
   graphql:
-    image:
-      name: base
-      command: src/api/handler.server
+    handler: src/api/handler.server
+    runtime: nodejs20.x
     events:
     - http:
         path: /


### PR DESCRIPTION
Trying to fix local development for animl-api. Seems like we need to move our animl-api lambda from being ran with an ecr image and instead using the native lambda execution environment now that it supports node20. Also updates serverless offline to run using the right profile and disable the authorizer.

Original changes from #178  and #180 