### PR TITLE
TypeScript: 1. Initial Tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 node_modules
 jspm_packages
 .build
+dist
 
 # Serverless directories
 .serverless

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -14,5 +14,5 @@ RUN export NODEV='20.12.2' \
 
 RUN npm install
 
-CMD npm run lint && npm test
+CMD npm run lint && npm run build && npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "superagent": "^6.1.0"
             },
             "devDependencies": {
-                "@tsconfig/node18": "^18",
+                "@tsconfig/node20": "^20",
                 "eslint": "^8.19.0",
                 "eslint-plugin-node": "^11.1.0",
                 "serverless": "^3.20.0",
@@ -3618,10 +3618,10 @@
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true
         },
-        "node_modules/@tsconfig/node18": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-            "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+        "node_modules/@tsconfig/node20": {
+            "version": "20.1.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+            "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
             "dev": true
         },
         "node_modules/@types/aws-lambda": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "superagent": "^6.1.0"
             },
             "devDependencies": {
+                "@tsconfig/node14": "^14.1.2",
                 "eslint": "^8.19.0",
                 "eslint-plugin-node": "^11.1.0",
                 "serverless": "^3.20.0",
@@ -48,6 +49,7 @@
                 "serverless-offline": "^13.0.0",
                 "sinon": "^17.0.0",
                 "tape": "^5.5.3",
+                "typescript": "^5.4.4",
                 "undici": "^6.0.0"
             }
         },
@@ -3613,6 +3615,12 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "14.1.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.2.tgz",
+            "integrity": "sha512-1vncsbfCZ3TBLPxesRYz02Rn7SNJfbLoDVkcZ7F/ixOV6nwxwgdhD1mdPcc5YQ413qBJ8CvMxXMFfJ7oawjo7Q==",
             "dev": true
         },
         "node_modules/@types/aws-lambda": {
@@ -11687,6 +11695,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+            "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "superagent": "^6.1.0"
             },
             "devDependencies": {
-                "@tsconfig/node14": "^14.1.2",
+                "@tsconfig/node18": "^18",
                 "eslint": "^8.19.0",
                 "eslint-plugin-node": "^11.1.0",
                 "serverless": "^3.20.0",
@@ -3618,10 +3618,10 @@
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true
         },
-        "node_modules/@tsconfig/node14": {
-            "version": "14.1.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.2.tgz",
-            "integrity": "sha512-1vncsbfCZ3TBLPxesRYz02Rn7SNJfbLoDVkcZ7F/ixOV6nwxwgdhD1mdPcc5YQ413qBJ8CvMxXMFfJ7oawjo7Q==",
+        "node_modules/@tsconfig/node18": {
+            "version": "18.2.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+            "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
             "dev": true
         },
         "node_modules/@types/aws-lambda": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "serverless": "^3.20.0",
                 "serverless-dotenv-plugin": "^6.0.0",
                 "serverless-offline": "^13.0.0",
+                "serverless-plugin-typescript": "^2.1.5",
                 "sinon": "^17.0.0",
                 "tape": "^5.5.3",
                 "typescript": "^5.4.4",
@@ -3679,6 +3680,16 @@
                 "@types/send": "*"
             }
         },
+        "node_modules/@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -3714,6 +3725,12 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+        },
+        "node_modules/@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+            "dev": true
         },
         "node_modules/@types/node": {
             "version": "20.11.30",
@@ -10694,6 +10711,75 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/serverless-plugin-typescript": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-typescript/-/serverless-plugin-typescript-2.1.5.tgz",
+            "integrity": "sha512-7OO6eJzv57dvfz0v9huU1JVBgdzgvvz+6GCwwkR2bfdVHKs1tifx+fSgjbQcBpXNNHf8Dx2Mo7evtYTkA/TDDA==",
+            "dev": true,
+            "dependencies": {
+                "fs-extra": "^7.0.1",
+                "globby": "^10.0.2",
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "peerDependencies": {
+                "serverless": "2 || 3",
+                "typescript": ">=2.2.2"
+            }
+        },
+        "node_modules/serverless-plugin-typescript/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/serverless-plugin-typescript/node_modules/globby": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+            "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+            "dev": true,
+            "dependencies": {
+                "@types/glob": "^7.1.1",
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.0.3",
+                "glob": "^7.1.3",
+                "ignore": "^5.1.1",
+                "merge2": "^1.2.3",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/serverless-plugin-typescript/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/serverless-plugin-typescript/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/serverless/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Lambda-based graphQL API for camera trap data management platform",
     "main": "src/handler.js",
     "scripts": {
-        "start": "serverless offline",
+        "start": "AWS_PROFILE=animl serverless offline --noAuth",
         "build": "tsc",
         "deploy-dev": "sls deploy --stage dev",
         "deploy-prod": "sls deploy --stage prod",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "serverless": "^3.20.0",
         "serverless-dotenv-plugin": "^6.0.0",
         "serverless-offline": "^13.0.0",
+        "serverless-plugin-typescript": "^2.1.5",
         "sinon": "^17.0.0",
         "tape": "^5.5.3",
         "typescript": "^5.4.4",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "superagent": "^6.1.0"
     },
     "devDependencies": {
+        "@tsconfig/node14": "^14.1.2",
         "eslint": "^8.19.0",
         "eslint-plugin-node": "^11.1.0",
         "serverless": "^3.20.0",
@@ -65,6 +66,7 @@
         "serverless-offline": "^13.0.0",
         "sinon": "^17.0.0",
         "tape": "^5.5.3",
+        "typescript": "^5.4.4",
         "undici": "^6.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "superagent": "^6.1.0"
     },
     "devDependencies": {
-        "@tsconfig/node18": "^18",
+        "@tsconfig/node20": "^20",
         "eslint": "^8.19.0",
         "eslint-plugin-node": "^11.1.0",
         "serverless": "^3.20.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "description": "Lambda-based graphQL API for camera trap data management platform",
     "main": "src/handler.js",
     "scripts": {
-        "start": "AWS_PROFILE=animl serverless offline --noAuth",
+        "start": "serverless offline",
+        "build": "tsc",
         "deploy-dev": "sls deploy --stage dev",
         "deploy-prod": "sls deploy --stage prod",
         "seed-db": "AWS_PROFILE=animl REGION=us-west-2 node ./src/scripts/seedDb.js",
@@ -58,7 +59,7 @@
         "superagent": "^6.1.0"
     },
     "devDependencies": {
-        "@tsconfig/node14": "^14.1.2",
+        "@tsconfig/node18": "^18",
         "eslint": "^8.19.0",
         "eslint-plugin-node": "^11.1.0",
         "serverless": "^3.20.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,7 @@ service: animl-api
 
 plugins:
   - serverless-offline
+  - serverless-plugin-typescript
 
 package:
   patterns:

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,8 +3,8 @@ app: animl
 service: animl-api
 
 plugins:
-  - serverless-offline
   - serverless-plugin-typescript
+  - serverless-offline
 
 custom:
   serverlessPluginTypescript:

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,10 @@ plugins:
   - serverless-offline
   - serverless-plugin-typescript
 
+custom:
+  serverlessPluginTypescript:
+    tsConfigFileLocation: './tsconfig.json'
+
 package:
   patterns:
     - '!backups/**'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-14-tsconfigjson
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-18-tsconfigjson
+  "extends": "@tsconfig/node20/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-20-tsconfigjson
   "compilerOptions": {
     "strict": true,
     "preserveConstEnums": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-14-tsconfigjson
   "compilerOptions": {
-    "outDir": "./dist",
+    "preserveConstEnums": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
     "allowJs": true,
+    "outDir": "./.build",
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-14-tsconfigjson
+  "extends": "@tsconfig/node18/tsconfig.json", // https://github.com/tsconfig/bases?tab=readme-ov-file#node-18-tsconfigjson
   "compilerOptions": {
+    "strict": true,
     "preserveConstEnums": true,
-    "strictNullChecks": true,
     "sourceMap": true,
     "allowJs": true,
     "outDir": "./.build",


### PR DESCRIPTION
## What I'm adding

Add basic initial tooling to support TypeScript within the project, without actually beginning any TypeScript conversion.

## How I did it

- Add `tsconfig.json` specifying recommended settings for targeting Node18, running in strict mode, permitting .js files
- Add build command to generate `.build` output
- Update Serverless settings to use TS build
- Update docker test file to build project

## How you can test it

After running `npm install --dev`, try the build with `npm run build -- --watch`. Deploying to staging and verifying that the application functions on the most basic level may be generally sufficient. 

---

Part of #187 