### PR TITLE
TypeScript: Resolvers(query.imageErrors): Add count to ImageErrors pageInfo object

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -381,6 +381,13 @@ export enum Format {
   Csv = 'csv'
 }
 
+export type IPageInfo = {
+  hasNext?: Maybe<Scalars['Boolean']['output']>;
+  hasPrevious?: Maybe<Scalars['Boolean']['output']>;
+  next?: Maybe<Scalars['String']['output']>;
+  previous?: Maybe<Scalars['String']['output']>;
+};
+
 export type Image = {
   __typename?: 'Image';
   _id: Scalars['ID']['output'];
@@ -790,7 +797,7 @@ export type ObjectUpdate = {
   objectId: Scalars['ID']['input'];
 };
 
-export type PageInfo = {
+export type PageInfo = IPageInfo & {
   __typename?: 'PageInfo';
   hasNext?: Maybe<Scalars['Boolean']['output']>;
   hasPrevious?: Maybe<Scalars['Boolean']['output']>;
@@ -798,7 +805,7 @@ export type PageInfo = {
   previous?: Maybe<Scalars['String']['output']>;
 };
 
-export type PageInfoWithCount = PageInfo & {
+export type PageInfoWithCount = IPageInfo & {
   __typename?: 'PageInfoWithCount';
   count?: Maybe<Scalars['Int']['output']>;
   hasNext?: Maybe<Scalars['Boolean']['output']>;

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -445,7 +445,7 @@ export type ImageError = {
 export type ImageErrorsConnection = {
   __typename?: 'ImageErrorsConnection';
   errors: Array<Maybe<ImageError>>;
-  pageInfo?: Maybe<PageInfo>;
+  pageInfo?: Maybe<PageInfoWithCount>;
 };
 
 export type ImageErrorsFilterInput = {
@@ -790,6 +790,11 @@ export type ObjectUpdate = {
   objectId: Scalars['ID']['input'];
 };
 
+export type PageCount = {
+  __typename?: 'PageCount';
+  count?: Maybe<Scalars['Int']['output']>;
+};
+
 export type PageInfo = {
   __typename?: 'PageInfo';
   hasNext?: Maybe<Scalars['Boolean']['output']>;
@@ -797,6 +802,8 @@ export type PageInfo = {
   next?: Maybe<Scalars['String']['output']>;
   previous?: Maybe<Scalars['String']['output']>;
 };
+
+export type PageInfoWithCount = PageCount | PageInfo;
 
 export type Point = {
   __typename?: 'Point';

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -790,11 +790,6 @@ export type ObjectUpdate = {
   objectId: Scalars['ID']['input'];
 };
 
-export type PageCount = {
-  __typename?: 'PageCount';
-  count?: Maybe<Scalars['Int']['output']>;
-};
-
 export type PageInfo = {
   __typename?: 'PageInfo';
   hasNext?: Maybe<Scalars['Boolean']['output']>;
@@ -803,7 +798,14 @@ export type PageInfo = {
   previous?: Maybe<Scalars['String']['output']>;
 };
 
-export type PageInfoWithCount = PageCount | PageInfo;
+export type PageInfoWithCount = PageInfo & {
+  __typename?: 'PageInfoWithCount';
+  count?: Maybe<Scalars['Int']['output']>;
+  hasNext?: Maybe<Scalars['Boolean']['output']>;
+  hasPrevious?: Maybe<Scalars['Boolean']['output']>;
+  next?: Maybe<Scalars['String']['output']>;
+  previous?: Maybe<Scalars['String']['output']>;
+};
 
 export type Point = {
   __typename?: 'Point';

--- a/src/api/type-defs/objects/PageInfo.ts
+++ b/src/api/type-defs/objects/PageInfo.ts
@@ -6,11 +6,13 @@ export default /* GraphQL */ `
     hasNext: Boolean
   }
 
-  type PageCount {
+  type PageInfoWithCount implements PageInfo {
+    previous: String
+    hasPrevious: Boolean
+    next: String
+    hasNext: Boolean
     count: Int
   }
-
-  union PageInfoWithCount = PageInfo | PageCount
 `;
 
 // TODO: should any of these be required?

--- a/src/api/type-defs/objects/PageInfo.ts
+++ b/src/api/type-defs/objects/PageInfo.ts
@@ -1,12 +1,19 @@
 export default /* GraphQL */ `
-  type PageInfo {
+  interface IPageInfo {
+    previous: String
+    hasPrevious: Boolean
+    next: String
+    hasNext: Boolean
+  }
+  
+  type PageInfo implements IPageInfo {
     previous: String
     hasPrevious: Boolean
     next: String
     hasNext: Boolean
   }
 
-  type PageInfoWithCount implements PageInfo {
+  type PageInfoWithCount implements IPageInfo {
     previous: String
     hasPrevious: Boolean
     next: String

--- a/src/api/type-defs/objects/PageInfo.ts
+++ b/src/api/type-defs/objects/PageInfo.ts
@@ -5,6 +5,12 @@ export default /* GraphQL */ `
     next: String
     hasNext: Boolean
   }
+
+  type PageCount {
+    count: Int
+  }
+
+  union PageInfoWithCount = PageInfo | PageCount
 `;
 
 // TODO: should any of these be required?

--- a/src/api/type-defs/payloads/ImageErrorsConnection.ts
+++ b/src/api/type-defs/payloads/ImageErrorsConnection.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type ImageErrorsConnection {
-    pageInfo: PageInfo
+    pageInfo: PageInfoWithCount
     errors: [ImageError]!
   }
 `;


### PR DESCRIPTION
Currently, in GraphQL, our types have us returning an `ImageErrorsConnection` from `Query.ImageErrors`:
https://github.com/tnc-ca-geo/animl-api/blob/5522f6a70c3cc9d0eddf7a5f75b673626f53bc27/src/api/type-defs/root/Query.js#L10

That type has a `PageInfo` object:
https://github.com/tnc-ca-geo/animl-api/blob/5522f6a70c3cc9d0eddf7a5f75b673626f53bc27/src/api/type-defs/payloads/ImageErrorsConnection.js#L2-L3

Which does not contain a `count` property:
https://github.com/tnc-ca-geo/animl-api/blob/5522f6a70c3cc9d0eddf7a5f75b673626f53bc27/src/api/type-defs/objects/PageInfo.js#L2-L7

However, in our resolver, we _are_ returning a `count`:
https://github.com/tnc-ca-geo/animl-api/blob/5522f6a70c3cc9d0eddf7a5f75b673626f53bc27/src/api/resolvers/Query.js#L68-L78

This PR adds a `count` to the response type to appease TypeScript.