### PR TITLE
TypeScript: Resolvers(query.tasks): Add PageInfo for Query.tasks response type

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1047,6 +1047,7 @@ export type Task = {
 
 export type TasksPayload = {
   __typename?: 'TasksPayload';
+  pageInfo: PageInfo;
   tasks: Array<Maybe<Task>>;
 };
 

--- a/src/api/type-defs/payloads/TasksPayload.ts
+++ b/src/api/type-defs/payloads/TasksPayload.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
   type TasksPayload {
     tasks: [Task]!
+    pageInfo: PageInfo!
   }
 `;


### PR DESCRIPTION
Current code returns a `pageInfo` property in `Query.tasks`, but we don't include that in the `TasksPayload` specified in the types:

https://github.com/tnc-ca-geo/animl-api/blob/27b3e3d955208ffdaa061aeced28689e76644ad4/src/api/type-defs/root/Query.ts#L4

https://github.com/tnc-ca-geo/animl-api/blob/286f7e693bd4078c709754ade5c667adbc923643/src/api/resolvers/Query.ts#L21-L37