### PR TITLE
TypeScript: Resolvers(query.task/stats/exportErrors/exportAnnotations): Return toObject() in order to convert `_id` to string

### DIFF
--- a/src/api/resolvers/Query.ts
+++ b/src/api/resolvers/Query.ts
@@ -7,7 +7,8 @@ export default {
     { input }: gql.QueryProjectsArgs,
     context: Context,
   ): Promise<gql.Project[]> => {
-    return context.models.Project.getProjects(input, context);
+    const projects = await context.models.Project.getProjects(input, context);
+    return projects.map((project) => project.toObject());
   },
 
   users: async (
@@ -118,7 +119,8 @@ export default {
     { input }: gql.QueryImageArgs,
     context: Context,
   ): Promise<gql.Image> => {
-    return context.models.Image.queryById(input.imageId, context);
+    const image = await context.models.Image.queryById(input.imageId, context);
+    return image.toObject();
   },
 
   wirelessCameras: async (
@@ -126,7 +128,8 @@ export default {
     { input }: gql.QueryWirelessCamerasArgs,
     context: Context,
   ): Promise<gql.WirelessCamera[]> => {
-    return context.models.Camera.getWirelessCameras(input, context);
+    const cameras = await context.models.Camera.getWirelessCameras(input, context);
+    return cameras.map((camera) => camera.toObject());
   },
 
   mlModels: async (

--- a/src/api/resolvers/Query.ts
+++ b/src/api/resolvers/Query.ts
@@ -37,7 +37,8 @@ export default {
   },
 
   task: async (_: unknown, { input }: gql.QueryTaskArgs, context: Context): Promise<gql.Task> => {
-    return context.models.Task.queryById(input.taskId, context);
+    const task = await context.models.Task.queryById(input.taskId, context);
+    return task.toObject();
   },
 
   batches: async (
@@ -137,7 +138,8 @@ export default {
   },
 
   stats: async (_: unknown, { input }: gql.QueryStatsArgs, context: Context): Promise<gql.Task> => {
-    return context.models.Image.getStats(input, context);
+    const task = await context.models.Image.getStats(input, context);
+    return task.toObject();
   },
 
   exportErrors: async (
@@ -145,7 +147,8 @@ export default {
     { input }: gql.QueryExportErrorsArgs,
     context: Context,
   ): Promise<gql.Task> => {
-    return context.models.ImageError.exportErrors(input, context);
+    const task = await context.models.ImageError.exportErrors(input, context);
+    return task.toObject();
   },
 
   exportAnnotations: async (
@@ -153,6 +156,7 @@ export default {
     { input }: gql.QueryExportAnnotationsArgs,
     context: Context,
   ): Promise<gql.Task> => {
-    return context.models.Image.exportAnnotations(input, context);
+    const task = await context.models.Image.exportAnnotations(input, context);
+    return task.toObject();
   },
 };


### PR DESCRIPTION
For any method where a `Task` is returned, we see the following error:

```ts
Type 'Document<unknown, {}, { type: "GetStats" | "ExportAnnotations" | "ExportImageErrors" | "CreateDeployment" | "UpdateDeployment" | "DeleteDeployment"; user: string; projectId: string; status: "SUBMITTED" | ... 2 more ... | "COMPLETE"; created: Date; updated: Date; output?: any; }> & { ...; } & { ...; }' is not assignable to type 'Task'.
  Types of property '_id' are incompatible.
    Type 'ObjectId' is not assignable to type 'string'.ts(2322)
```

This seems to be an issue where GraphQL expected the `_id` to be a string:

https://github.com/tnc-ca-geo/animl-api/blob/27b3e3d955208ffdaa061aeced28689e76644ad4/src/@types/graphql.ts#L1038
https://github.com/tnc-ca-geo/animl-api/blob/27b3e3d955208ffdaa061aeced28689e76644ad4/src/@types/graphql.ts#L10


However, Mongoose shows it as an `mongoose.Types.ObjectId`. Calling `.toObject()` on the response object rectifies this.  This may become a common pattern for our resolvers...  I would like to imagine that there's a better way to handle this, but I'm not sure what that would be, perhaps something with the Scalars for the output?
