### PR TITLE
TypeScript: Resolvers(mutations.createUser): Ensure StandardPayload is returned

### DIFF
--- a/src/api/db/models/User.js
+++ b/src/api/db/models/User.js
@@ -49,7 +49,7 @@ export class UserModel {
         UserPoolId: context.config['/APPLICATION/COGNITO/USERPOOLID']
       }));
 
-      await this.update({
+      return this.update({
         username: input.username,
         roles: input.roles
       }, context);


### PR DESCRIPTION
In `mutations.createUser`, we are expected to return a `StandardPayload`:

https://github.com/tnc-ca-geo/animl-api/blob/27b3e3d955208ffdaa061aeced28689e76644ad4/src/api/type-defs/root/Mutation.ts#L10

https://github.com/tnc-ca-geo/animl-api/blob/27b3e3d955208ffdaa061aeced28689e76644ad4/src/api/type-defs/payloads/StandardPayload.ts#L1-L5

However, it's possible that the handler returns `undefined` if no exception is thrown:
https://github.com/tnc-ca-geo/animl-api/blob/a2483e87a4ddaa1aab673aec3aa2df7991980f25/src/api/db/models/User.js#L43-L89

This PR resolves that, ensuring that a `StandardPayload` is always returned (unless an uncaught error is raised).
