### PR TITLE
Mark all values in arrays as required

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -94,7 +94,7 @@ export type BatchPayload = {
 
 export type BatchesConnection = {
   __typename?: 'BatchesConnection';
-  batches: Array<Maybe<Batch>>;
+  batches: Array<Batch>;
   pageInfo?: Maybe<PageInfo>;
 };
 
@@ -122,7 +122,7 @@ export type ClearImageErrorsInput = {
 export type CloseUploadInput = {
   batchId: Scalars['String']['input'];
   multipartUploadId: Scalars['String']['input'];
-  parts: Array<InputMaybe<CloseUploadPart>>;
+  parts: Array<CloseUploadPart>;
 };
 
 export type CloseUploadPart = {
@@ -170,7 +170,7 @@ export type CreateInternalLabelInput = {
 };
 
 export type CreateInternalLabelsInput = {
-  labels: Array<InputMaybe<CreateInternalLabelInput>>;
+  labels: Array<CreateInternalLabelInput>;
 };
 
 export type CreateLabelInput = {
@@ -186,7 +186,7 @@ export type CreateLabelInput = {
 };
 
 export type CreateLabelsInput = {
-  labels: Array<InputMaybe<CreateLabelInput>>;
+  labels: Array<CreateLabelInput>;
 };
 
 export type CreateObjectInput = {
@@ -195,11 +195,11 @@ export type CreateObjectInput = {
 };
 
 export type CreateObjectsInput = {
-  objects: Array<InputMaybe<CreateObjectInput>>;
+  objects: Array<CreateObjectInput>;
 };
 
 export type CreateProjectInput = {
-  availableMLModels: Array<InputMaybe<Scalars['String']['input']>>;
+  availableMLModels: Array<Scalars['String']['input']>;
   description: Scalars['String']['input'];
   name: Scalars['String']['input'];
   timezone: Scalars['String']['input'];
@@ -263,7 +263,7 @@ export type DeleteLabelInput = {
 };
 
 export type DeleteLabelsInput = {
-  labels: Array<InputMaybe<DeleteLabelInput>>;
+  labels: Array<DeleteLabelInput>;
 };
 
 export type DeleteObjectInput = {
@@ -272,7 +272,7 @@ export type DeleteObjectInput = {
 };
 
 export type DeleteObjectsInput = {
-  objects: Array<InputMaybe<DeleteObjectInput>>;
+  objects: Array<DeleteObjectInput>;
 };
 
 export type DeleteProjectLabelInput = {
@@ -444,7 +444,7 @@ export type ImageError = {
 
 export type ImageErrorsConnection = {
   __typename?: 'ImageErrorsConnection';
-  errors: Array<Maybe<ImageError>>;
+  errors: Array<ImageError>;
   pageInfo?: Maybe<PageInfo>;
 };
 
@@ -474,7 +474,7 @@ export type ImageMetadata = {
 
 export type ImagesConnection = {
   __typename?: 'ImagesConnection';
-  images: Array<Maybe<Image>>;
+  images: Array<Image>;
   pageInfo?: Maybe<PageInfo>;
 };
 
@@ -1047,7 +1047,7 @@ export type Task = {
 
 export type TasksPayload = {
   __typename?: 'TasksPayload';
-  tasks: Array<Maybe<Task>>;
+  tasks: Array<Task>;
 };
 
 export type UnregisterCameraInput = {
@@ -1094,11 +1094,11 @@ export type UpdateImageCommentInput = {
 };
 
 export type UpdateLabelsInput = {
-  updates: Array<InputMaybe<LabelUpdate>>;
+  updates: Array<LabelUpdate>;
 };
 
 export type UpdateObjectsInput = {
-  updates: Array<InputMaybe<ObjectUpdate>>;
+  updates: Array<ObjectUpdate>;
 };
 
 export type UpdateProjectInput = {
@@ -1133,7 +1133,7 @@ export type User = {
   created: Scalars['String']['output'];
   email: Scalars['String']['output'];
   enabled: Scalars['Boolean']['output'];
-  roles: Array<Maybe<UserRole>>;
+  roles: Array<UserRole>;
   status: Scalars['String']['output'];
   updated: Scalars['String']['output'];
   username: Scalars['String']['output'];
@@ -1147,7 +1147,7 @@ export enum UserRole {
 
 export type UsersPayload = {
   __typename?: 'UsersPayload';
-  users: Array<Maybe<User>>;
+  users: Array<User>;
 };
 
 export type Validation = {

--- a/src/api/type-defs/inputs/CloseUploadInput.ts
+++ b/src/api/type-defs/inputs/CloseUploadInput.ts
@@ -7,6 +7,6 @@ export default /* GraphQL */ `
   input CloseUploadInput {
     batchId: String!
     multipartUploadId: String!
-    parts: [CloseUploadPart]!
+    parts: [CloseUploadPart!]!
   }
 `;

--- a/src/api/type-defs/inputs/CreateInternalLabelsInput.ts
+++ b/src/api/type-defs/inputs/CreateInternalLabelsInput.ts
@@ -9,6 +9,6 @@ export default /* GraphQL */ `
   }
 
   input CreateInternalLabelsInput {
-    labels: [CreateInternalLabelInput]!
+    labels: [CreateInternalLabelInput!]!
   }
 `;

--- a/src/api/type-defs/inputs/CreateLabelsInput.ts
+++ b/src/api/type-defs/inputs/CreateLabelsInput.ts
@@ -18,6 +18,6 @@ export default /* GraphQL */ `
   }
 
   input CreateLabelsInput {
-    labels: [CreateLabelInput]!
+    labels: [CreateLabelInput!]!
   }
 `;

--- a/src/api/type-defs/inputs/CreateObjectsInput.ts
+++ b/src/api/type-defs/inputs/CreateObjectsInput.ts
@@ -12,6 +12,6 @@ export default /* GraphQL */ `
   }
 
   input CreateObjectsInput {
-    objects: [CreateObjectInput]!
+    objects: [CreateObjectInput!]!
   }
 `;

--- a/src/api/type-defs/inputs/CreateProjectInput.ts
+++ b/src/api/type-defs/inputs/CreateProjectInput.ts
@@ -3,6 +3,6 @@ export default /* GraphQL */ `
     name: String!
     description: String!
     timezone: String!
-    availableMLModels: [String]!
+    availableMLModels: [String!]!
   }
 `;

--- a/src/api/type-defs/inputs/DeleteLabelsInput.ts
+++ b/src/api/type-defs/inputs/DeleteLabelsInput.ts
@@ -6,6 +6,6 @@ export default /* GraphQL */ `
   }
 
   input DeleteLabelsInput {
-    labels: [DeleteLabelInput]!
+    labels: [DeleteLabelInput!]!
   }
 `;

--- a/src/api/type-defs/inputs/DeleteObjectsInput.ts
+++ b/src/api/type-defs/inputs/DeleteObjectsInput.ts
@@ -5,6 +5,6 @@ export default /* GraphQL */ `
   }
 
   input DeleteObjectsInput {
-    objects: [DeleteObjectInput]!
+    objects: [DeleteObjectInput!]!
   }
 `;

--- a/src/api/type-defs/inputs/UpdateLabelsInput.ts
+++ b/src/api/type-defs/inputs/UpdateLabelsInput.ts
@@ -12,6 +12,6 @@ export default /* GraphQL */ `
   }
 
   input UpdateLabelsInput {
-    updates: [LabelUpdate]!
+    updates: [LabelUpdate!]!
   }
 `;

--- a/src/api/type-defs/inputs/UpdateObjectsInput.ts
+++ b/src/api/type-defs/inputs/UpdateObjectsInput.ts
@@ -11,6 +11,6 @@ export default /* GraphQL */ `
   }
 
   input UpdateObjectsInput {
-    updates: [ObjectUpdate]!
+    updates: [ObjectUpdate!]!
   }
 `;

--- a/src/api/type-defs/objects/User.ts
+++ b/src/api/type-defs/objects/User.ts
@@ -6,7 +6,7 @@ export default /* GraphQL */ `
   }
 
   type User {
-    roles: [UserRole]!
+    roles: [UserRole!]!
     username: String!
     email: String!
     created: String!

--- a/src/api/type-defs/payloads/BatchesConnection.ts
+++ b/src/api/type-defs/payloads/BatchesConnection.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type BatchesConnection {
     pageInfo: PageInfo
-    batches: [Batch]!
+    batches: [Batch!]!
   }
 `;

--- a/src/api/type-defs/payloads/ImageErrorsConnection.ts
+++ b/src/api/type-defs/payloads/ImageErrorsConnection.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type ImageErrorsConnection {
     pageInfo: PageInfo
-    errors: [ImageError]!
+    errors: [ImageError!]!
   }
 `;

--- a/src/api/type-defs/payloads/ImagesConnection.ts
+++ b/src/api/type-defs/payloads/ImagesConnection.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type ImagesConnection {
     pageInfo: PageInfo
-    images: [Image]!
+    images: [Image!]!
   }
 `;

--- a/src/api/type-defs/payloads/TasksPayload.ts
+++ b/src/api/type-defs/payloads/TasksPayload.ts
@@ -1,5 +1,5 @@
 export default /* GraphQL */ `
   type TasksPayload {
-    tasks: [Task]!
+    tasks: [Task!]!
   }
 `;

--- a/src/api/type-defs/payloads/UsersPayload.ts
+++ b/src/api/type-defs/payloads/UsersPayload.ts
@@ -1,5 +1,5 @@
 export default /* GraphQL */ `
   type UsersPayload {
-    users: [User]!
+    users: [User!]!
   }
 `;


### PR DESCRIPTION
## What I'm changing

I get the impression that any array argument we take in within our GraphQL API should only contain records of a specific type, never `null` values.  This PR ensures that all arrays (optional or required) expects non-null values.

## How I did it

Find and replace.