### PR TITLE
Abort user lookup if no x-selected-project header is available

### DIFF
--- a/src/api/auth/authorization.ts
+++ b/src/api/auth/authorization.ts
@@ -30,7 +30,8 @@ async function getUserInfo(req: APIGatewayProxyEvent, config: Config): Promise<U
   );
 
   // add selected project info to user
-  const selectedProject = req.headers['x-selected-project'] || '';
+  const selectedProject = req.headers['x-selected-project'];
+  if (!selectedProject) return null;
   user['curr_project'] = selectedProject;
 
   // parse cognito groups into projects
@@ -63,7 +64,7 @@ export interface User {
   aud: string;
   'cognito:username': string;
   is_superuser: boolean;
-  curr_project: string | null;
+  curr_project: string;
   projects: Record<string, { roles: string[] }>;
   curr_project_roles: string[];
 }


### PR DESCRIPTION
Rather than supporting `null` `curr_project` values on the user, we will abort user lookup if no header is present.

Downstream, an error will be thrown:

https://github.com/tnc-ca-geo/animl-api/blob/d2efca993fd1107776272d06ff5c643435878bcb/src/api/handler.ts#L49-L51