### PR TITLE
FIX: Pass in input.filters to ImageError.countImageErrors()

### DIFF
--- a/src/api/resolvers/Query.ts
+++ b/src/api/resolvers/Query.ts
@@ -97,7 +97,7 @@ export default {
     { input }: gql.QueryImageErrorsArgs,
     context: Context,
   ): Promise<gql.ImageErrorsConnection> => {
-    const count = await context.models.ImageError.countImageErrors(input);
+    const count = await context.models.ImageError.countImageErrors(input.filters);
     const response = await context.models.ImageError.queryByFilter(input);
     const { previous, hasPrevious, next, hasNext, results } = response;
     return {


### PR DESCRIPTION
It seems that we are incorrectly passing arguments from GQL to the model.  Not sure how this was introduced, I believe it is a long-standing bug.
