### PR TITLE
GraphQL: Mark all array values as non-null

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -18,7 +18,7 @@ export type Scalars = {
 
 export type AutomationAction = {
   __typename?: 'AutomationAction';
-  alertRecipients?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  alertRecipients?: Maybe<Array<Scalars['String']['output']>>;
   categoryConfig?: Maybe<Scalars['JSONObject']['output']>;
   confThreshold?: Maybe<Scalars['Float']['output']>;
   mlModel?: Maybe<Scalars['String']['output']>;
@@ -26,7 +26,7 @@ export type AutomationAction = {
 };
 
 export type AutomationActionInput = {
-  alertRecipients?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  alertRecipients?: InputMaybe<Array<Scalars['String']['input']>>;
   categoryConfig?: InputMaybe<Scalars['JSONObject']['input']>;
   confThreshold?: InputMaybe<Scalars['Float']['input']>;
   mlModel?: InputMaybe<Scalars['String']['input']>;
@@ -64,7 +64,7 @@ export type Batch = {
   _id: Scalars['String']['output'];
   created?: Maybe<Scalars['Date']['output']>;
   dead?: Maybe<Scalars['Int']['output']>;
-  errors?: Maybe<Array<Maybe<BatchError>>>;
+  errors?: Maybe<Array<BatchError>>;
   imageErrors?: Maybe<Scalars['Int']['output']>;
   ingestionComplete?: Maybe<Scalars['Date']['output']>;
   originalFile?: Maybe<Scalars['String']['output']>;
@@ -221,7 +221,7 @@ export type CreateUploadPayload = {
   batch: Scalars['String']['output'];
   multipartUploadId?: Maybe<Scalars['String']['output']>;
   url?: Maybe<Scalars['String']['output']>;
-  urls?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  urls?: Maybe<Array<Scalars['String']['output']>>;
   user: Scalars['String']['output'];
 };
 
@@ -344,7 +344,7 @@ export type ExportStatusInput = {
 export type ExportStatusPayload = {
   __typename?: 'ExportStatusPayload';
   count?: Maybe<Scalars['Int']['output']>;
-  error?: Maybe<Array<Maybe<ExportError>>>;
+  error?: Maybe<Array<ExportError>>;
   meta?: Maybe<Scalars['JSONObject']['output']>;
   status: Scalars['String']['output'];
   url?: Maybe<Scalars['String']['output']>;
@@ -354,12 +354,12 @@ export type Filters = {
   __typename?: 'Filters';
   addedEnd?: Maybe<Scalars['Date']['output']>;
   addedStart?: Maybe<Scalars['Date']['output']>;
-  cameras?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  cameras?: Maybe<Array<Scalars['String']['output']>>;
   createdEnd?: Maybe<Scalars['Date']['output']>;
   createdStart?: Maybe<Scalars['Date']['output']>;
   custom?: Maybe<Scalars['String']['output']>;
-  deployments?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  labels?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  deployments?: Maybe<Array<Scalars['String']['output']>>;
+  labels?: Maybe<Array<Scalars['String']['output']>>;
   notReviewed?: Maybe<Scalars['Boolean']['output']>;
   reviewed?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -372,7 +372,7 @@ export type FiltersInput = {
   createdStart?: InputMaybe<Scalars['Date']['input']>;
   custom?: InputMaybe<Scalars['String']['input']>;
   deployments?: InputMaybe<Array<Scalars['String']['input']>>;
-  labels?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  labels?: InputMaybe<Array<Scalars['String']['input']>>;
   reviewed?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -387,11 +387,11 @@ export type Image = {
   batchId?: Maybe<Scalars['String']['output']>;
   bucket: Scalars['String']['output'];
   cameraId: Scalars['String']['output'];
-  comments?: Maybe<Array<Maybe<ImageComment>>>;
+  comments?: Maybe<Array<ImageComment>>;
   dateAdded: Scalars['Date']['output'];
   dateTimeOriginal: Scalars['Date']['output'];
   deploymentId: Scalars['ID']['output'];
-  errors?: Maybe<Array<Maybe<ImageError>>>;
+  errors?: Maybe<Array<ImageError>>;
   fileTypeExtension: Scalars['String']['output'];
   imageBytes?: Maybe<Scalars['Int']['output']>;
   imageHeight?: Maybe<Scalars['Int']['output']>;
@@ -400,7 +400,7 @@ export type Image = {
   make: Scalars['String']['output'];
   mimeType?: Maybe<Scalars['String']['output']>;
   model?: Maybe<Scalars['String']['output']>;
-  objects?: Maybe<Array<Maybe<Object>>>;
+  objects?: Maybe<Array<Object>>;
   originalFileName?: Maybe<Scalars['String']['output']>;
   path?: Maybe<Scalars['String']['output']>;
   projectId: Scalars['String']['output'];
@@ -414,7 +414,7 @@ export type ImageAttempt = {
   _id: Scalars['ID']['output'];
   batch?: Maybe<Scalars['String']['output']>;
   created: Scalars['Date']['output'];
-  errors?: Maybe<Array<Maybe<ImageError>>>;
+  errors?: Maybe<Array<ImageError>>;
   metadata?: Maybe<ImageMetadata>;
   projectId: Scalars['String']['output'];
 };
@@ -429,7 +429,7 @@ export type ImageComment = {
 
 export type ImageCommentsPayload = {
   __typename?: 'ImageCommentsPayload';
-  comments?: Maybe<Array<Maybe<ImageComment>>>;
+  comments?: Maybe<Array<ImageComment>>;
 };
 
 export type ImageError = {
@@ -504,7 +504,7 @@ export type LabelDiffsInput = {
 
 export type LabelList = {
   __typename?: 'LabelList';
-  categories?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  categories?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 export type LabelUpdate = {
@@ -532,7 +532,7 @@ export type LocationInput = {
 export type MlModel = {
   __typename?: 'MLModel';
   _id: Scalars['String']['output'];
-  categories?: Maybe<Array<Maybe<Categories>>>;
+  categories?: Maybe<Array<Categories>>;
   defaultConfThreshold?: Maybe<Scalars['Float']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   version: Scalars['String']['output'];
@@ -768,7 +768,7 @@ export type Object = {
   __typename?: 'Object';
   _id: Scalars['ID']['output'];
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
-  labels?: Maybe<Array<Maybe<Label>>>;
+  labels?: Maybe<Array<Label>>;
   locked: Scalars['Boolean']['output'];
 };
 
@@ -780,7 +780,7 @@ export type ObjectDiffsInput = {
 export type ObjectInput = {
   _id: Scalars['ID']['input'];
   bbox?: InputMaybe<Array<Scalars['Float']['input']>>;
-  labels?: InputMaybe<Array<InputMaybe<CreateLabelInput>>>;
+  labels?: InputMaybe<Array<CreateLabelInput>>;
   locked: Scalars['Boolean']['input'];
 };
 
@@ -812,11 +812,11 @@ export type PointInput = {
 export type Project = {
   __typename?: 'Project';
   _id: Scalars['String']['output'];
-  automationRules?: Maybe<Array<Maybe<AutomationRule>>>;
-  availableMLModels?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  cameraConfigs?: Maybe<Array<Maybe<CameraConfig>>>;
+  automationRules?: Maybe<Array<AutomationRule>>;
+  availableMLModels?: Maybe<Array<Scalars['String']['output']>>;
+  cameraConfigs?: Maybe<Array<CameraConfig>>;
   description?: Maybe<Scalars['String']['output']>;
-  labels?: Maybe<Array<Maybe<ProjectLabel>>>;
+  labels?: Maybe<Array<ProjectLabel>>;
   name: Scalars['String']['output'];
   timezone: Scalars['String']['output'];
   views: Array<View>;
@@ -857,13 +857,13 @@ export type Query = {
   images?: Maybe<ImagesConnection>;
   imagesCount?: Maybe<ImagesCount>;
   labels?: Maybe<LabelList>;
-  mlModels?: Maybe<Array<Maybe<MlModel>>>;
-  projects?: Maybe<Array<Maybe<Project>>>;
+  mlModels?: Maybe<Array<MlModel>>;
+  projects?: Maybe<Array<Project>>;
   stats?: Maybe<Task>;
   task?: Maybe<Task>;
   tasks?: Maybe<TasksPayload>;
   users?: Maybe<UsersPayload>;
-  wirelessCameras?: Maybe<Array<Maybe<WirelessCamera>>>;
+  wirelessCameras?: Maybe<Array<WirelessCamera>>;
 };
 
 
@@ -1015,12 +1015,12 @@ export type RegisterCameraInput = {
 export type RegisterCameraPayload = {
   __typename?: 'RegisterCameraPayload';
   project?: Maybe<Project>;
-  wirelessCameras?: Maybe<Array<Maybe<WirelessCamera>>>;
+  wirelessCameras?: Maybe<Array<WirelessCamera>>;
 };
 
 export type StandardErrorPayload = {
   __typename?: 'StandardErrorPayload';
-  errors?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  errors?: Maybe<Array<Scalars['String']['output']>>;
   isOk?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -1057,16 +1057,16 @@ export type UnregisterCameraInput = {
 export type UnregisterCameraPayload = {
   __typename?: 'UnregisterCameraPayload';
   project?: Maybe<Project>;
-  wirelessCameras?: Maybe<Array<Maybe<WirelessCamera>>>;
+  wirelessCameras?: Maybe<Array<WirelessCamera>>;
 };
 
 export type UpdateAutomationRulesInput = {
-  automationRules?: InputMaybe<Array<InputMaybe<AutomationRuleInput>>>;
+  automationRules?: InputMaybe<Array<AutomationRuleInput>>;
 };
 
 export type UpdateAutomationRulesPayload = {
   __typename?: 'UpdateAutomationRulesPayload';
-  automationRules?: Maybe<Array<Maybe<AutomationRule>>>;
+  automationRules?: Maybe<Array<AutomationRule>>;
 };
 
 export type UpdateBatchInput = {

--- a/src/api/type-defs/inputs/CreateObjectsInput.ts
+++ b/src/api/type-defs/inputs/CreateObjectsInput.ts
@@ -3,7 +3,7 @@ export default /* GraphQL */ `
     _id: ID!
     bbox: [Float!]
     locked: Boolean!
-    labels: [CreateLabelInput]
+    labels: [CreateLabelInput!]
   }
 
   input CreateObjectInput {

--- a/src/api/type-defs/inputs/QueryImagesInput.ts
+++ b/src/api/type-defs/inputs/QueryImagesInput.ts
@@ -6,7 +6,7 @@ export default /* GraphQL */ `
     addedEnd: Date
     cameras: [String!]
     deployments: [String!]
-    labels: [String]
+    labels: [String!]
     reviewed: Boolean
     custom: String
   }

--- a/src/api/type-defs/inputs/UpdateAutomationRulesInput.ts
+++ b/src/api/type-defs/inputs/UpdateAutomationRulesInput.ts
@@ -7,7 +7,7 @@ export default /* GraphQL */ `
   input AutomationActionInput {
     type: String!
     mlModel: String
-    alertRecipients: [String]
+    alertRecipients: [String!]
     confThreshold: Float
     categoryConfig: JSONObject
   }
@@ -20,6 +20,6 @@ export default /* GraphQL */ `
   }
 
   input UpdateAutomationRulesInput {
-    automationRules: [AutomationRuleInput]
+    automationRules: [AutomationRuleInput!]
   }
 `;

--- a/src/api/type-defs/objects/AutomationRule.ts
+++ b/src/api/type-defs/objects/AutomationRule.ts
@@ -6,7 +6,7 @@ export default /* GraphQL */ `
 
   type AutomationAction {
     type: String!
-    alertRecipients: [String]
+    alertRecipients: [String!]
     mlModel: String
     confThreshold: Float
     categoryConfig: JSONObject

--- a/src/api/type-defs/objects/Batch.ts
+++ b/src/api/type-defs/objects/Batch.ts
@@ -3,7 +3,7 @@ export default /* GraphQL */ `
     _id: String!
     projectId: String!
     created: Date
-    errors: [BatchError]
+    errors: [BatchError!]
     imageErrors: Int
     uploadComplete: Date
     ingestionComplete: Date

--- a/src/api/type-defs/objects/Filters.ts
+++ b/src/api/type-defs/objects/Filters.ts
@@ -1,8 +1,8 @@
 export default /* GraphQL */ `
   type Filters {
-    cameras: [String]
-    deployments: [String]
-    labels: [String]
+    cameras: [String!]
+    deployments: [String!]
+    labels: [String!]
     createdStart: Date
     createdEnd: Date
     addedStart: Date

--- a/src/api/type-defs/objects/Image.ts
+++ b/src/api/type-defs/objects/Image.ts
@@ -2,7 +2,7 @@ export default /* GraphQL */ `
   type Image {
     _id: ID!
     batchId: String
-    errors: [ImageError]
+    errors: [ImageError!]
     bucket: String!
     fileTypeExtension: String!
     path: String
@@ -22,7 +22,7 @@ export default /* GraphQL */ `
     model: String
     location: Location
     reviewed: Boolean
-    objects: [Object]
-    comments: [ImageComment]
+    objects: [Object!]
+    comments: [ImageComment!]
   }
 `;

--- a/src/api/type-defs/objects/ImageAttempt.ts
+++ b/src/api/type-defs/objects/ImageAttempt.ts
@@ -24,6 +24,6 @@ export default /* GraphQL */ `
     batch: String
     created: Date!
     metadata: ImageMetadata
-    errors: [ImageError]
+    errors: [ImageError!]
   }
 `;

--- a/src/api/type-defs/objects/Label.ts
+++ b/src/api/type-defs/objects/Label.ts
@@ -19,13 +19,13 @@ export default /* GraphQL */ `
   }
 
   type LabelList {
-    categories: [String]
+    categories: [String!]
   }
 
   type Object {
     _id: ID!
     bbox: [Float!]
     locked: Boolean!
-    labels: [Label]
+    labels: [Label!]
   }
 `;

--- a/src/api/type-defs/objects/MLModel.ts
+++ b/src/api/type-defs/objects/MLModel.ts
@@ -10,6 +10,6 @@ export default /* GraphQL */ `
     description: String
     version: String!
     defaultConfThreshold: Float
-    categories: [Categories]
+    categories: [Categories!]
   }
 `;

--- a/src/api/type-defs/objects/Project.ts
+++ b/src/api/type-defs/objects/Project.ts
@@ -27,9 +27,9 @@ export default /* GraphQL */ `
     timezone: String!
     description: String
     views: [View!]!
-    automationRules: [AutomationRule]
-    cameraConfigs: [CameraConfig]
-    labels: [ProjectLabel]
-    availableMLModels: [String]
+    automationRules: [AutomationRule!]
+    cameraConfigs: [CameraConfig!]
+    labels: [ProjectLabel!]
+    availableMLModels: [String!]
   }
 `;

--- a/src/api/type-defs/payloads/CreateUploadPayload.ts
+++ b/src/api/type-defs/payloads/CreateUploadPayload.ts
@@ -4,6 +4,6 @@ export default /* GraphQL */ `
     multipartUploadId: String
     user: String!
     url: String
-    urls: [String]
+    urls: [String!]
   }
 `;

--- a/src/api/type-defs/payloads/ExportStatusPayload.ts
+++ b/src/api/type-defs/payloads/ExportStatusPayload.ts
@@ -8,6 +8,6 @@ export default /* GraphQL */ `
     url: String
     count: Int
     meta: JSONObject
-    error: [ExportError]
+    error: [ExportError!]
   }
 `;

--- a/src/api/type-defs/payloads/ImageCommentsPayload.ts
+++ b/src/api/type-defs/payloads/ImageCommentsPayload.ts
@@ -1,5 +1,5 @@
 export default /* GraphQL */ `
   type ImageCommentsPayload {
-    comments: [ImageComment]
+    comments: [ImageComment!]
   }
 `;

--- a/src/api/type-defs/payloads/RegisterCameraPayload.ts
+++ b/src/api/type-defs/payloads/RegisterCameraPayload.ts
@@ -1,7 +1,7 @@
 export default /* GraphQL */ `
   type RegisterCameraPayload {
     project: Project
-    wirelessCameras: [WirelessCamera]
+    wirelessCameras: [WirelessCamera!]
   }
 `;
 

--- a/src/api/type-defs/payloads/StandardErrorPayload.ts
+++ b/src/api/type-defs/payloads/StandardErrorPayload.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type StandardErrorPayload {
     isOk: Boolean
-    errors: [String]
+    errors: [String!]
   }
 `;

--- a/src/api/type-defs/payloads/UnregisterCameraPayload.ts
+++ b/src/api/type-defs/payloads/UnregisterCameraPayload.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   type UnregisterCameraPayload {
     project: Project
-    wirelessCameras: [WirelessCamera]
+    wirelessCameras: [WirelessCamera!]
   }
 `;

--- a/src/api/type-defs/payloads/UpdateAutomationRulesPayload.ts
+++ b/src/api/type-defs/payloads/UpdateAutomationRulesPayload.ts
@@ -1,5 +1,5 @@
 export default /* GraphQL */ `
   type UpdateAutomationRulesPayload {
-    automationRules: [AutomationRule]
+    automationRules: [AutomationRule!]
   }
 `;

--- a/src/api/type-defs/root/Query.ts
+++ b/src/api/type-defs/root/Query.ts
@@ -3,14 +3,14 @@ export default /* GraphQL */ `
     users(input: QueryUsersInput): UsersPayload
     tasks(input: QueryTasksInput): TasksPayload
     task(input: QueryTaskInput!): Task
-    projects(input: QueryProjectsInput): [Project]
+    projects(input: QueryProjectsInput): [Project!]
     image(input: QueryImageInput!): Image
     images(input: QueryImagesInput!): ImagesConnection
     imagesCount(input: QueryImagesCountInput!): ImagesCount
     imageErrors(input: QueryImageErrorsInput!): ImageErrorsConnection
     labels: LabelList
-    wirelessCameras(input: QueryWirelessCamerasInput): [WirelessCamera]
-    mlModels(input: QueryMLModelsInput): [MLModel]
+    wirelessCameras(input: QueryWirelessCamerasInput): [WirelessCamera!]
+    mlModels(input: QueryMLModelsInput): [MLModel!]
     batches(input: QueryBatchesInput!): BatchesConnection
     exportAnnotations(input: ExportInput!): Task
     exportErrors(input: ExportErrorsInput!): Task


### PR DESCRIPTION
In #222, we fell a bit short of our find/replace for all array values.  This PR corrects that, marking all GraphQL arrays as non-null values.

(note: this branch name had a typo, should be called `fix/graphql/bulk-change-array-types`)