### PR TITLE
FIX: Correct user type

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1130,12 +1130,12 @@ export type UpdateViewPayload = {
 
 export type User = {
   __typename?: 'User';
-  created: Scalars['String']['output'];
-  email: Scalars['String']['output'];
-  enabled: Scalars['Boolean']['output'];
+  created?: Maybe<Scalars['Date']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  enabled?: Maybe<Scalars['Boolean']['output']>;
   roles: Array<UserRole>;
-  status: Scalars['String']['output'];
-  updated: Scalars['String']['output'];
+  status?: Maybe<Scalars['String']['output']>;
+  updated?: Maybe<Scalars['Date']['output']>;
   username: Scalars['String']['output'];
 };
 

--- a/src/api/db/models/User.ts
+++ b/src/api/db/models/User.ts
@@ -250,13 +250,12 @@ export default class AuthedUserModel extends BaseAuthedModel {
   }
 }
 
-type UserWithRole = Cognito.UserType & { role: string };
 interface CognitoUser {
-  roles: string[];
+  roles: gql.UserRole[];
   username: string;
-  email: string | undefined;
-  created: Date | undefined;
-  updated: Date | undefined;
-  enabled: boolean | undefined;
-  status: Cognito.UserStatusType | undefined;
+  email?: string;
+  created?: Date;
+  updated?: Date;
+  enabled?: boolean;
+  status?: Cognito.UserStatusType;
 }

--- a/src/api/type-defs/objects/User.ts
+++ b/src/api/type-defs/objects/User.ts
@@ -8,10 +8,10 @@ export default /* GraphQL */ `
   type User {
     roles: [UserRole!]!
     username: String!
-    email: String!
-    created: String!
-    updated: String!
-    enabled: Boolean!
-    status: String!
+    email: String
+    created: Date
+    updated: Date
+    enabled: Boolean
+    status: String
   }
 `;


### PR DESCRIPTION
Update user types to comply with Cognito API response.

All user props from Cognito aside from `username` are optional. 

Additionally, dates are retypes as a `Date` type in GQL.