### PR TITLE
FIX: Add _id property on subdocuments

### DIFF
--- a/src/api/db/schemas/Project.ts
+++ b/src/api/db/schemas/Project.ts
@@ -46,6 +46,7 @@ const FiltersSchema = new Schema({
 });
 
 const ViewSchema = new Schema({
+  _id: { type: Schema.Types.ObjectId, required: true },
   name: { type: String, required: true },
   filters: { type: FiltersSchema, required: true },
   description: { type: String },
@@ -53,6 +54,7 @@ const ViewSchema = new Schema({
 });
 
 const DeploymentSchema = new Schema({
+  _id: { type: Schema.Types.ObjectId, required: true },
   name: { type: String, required: true },
   description: { type: String },
   location: { type: LocationSchema },

--- a/src/api/db/schemas/Task.ts
+++ b/src/api/db/schemas/Task.ts
@@ -4,6 +4,7 @@ import MongoPaging from 'mongo-cursor-pagination';
 const Schema = mongoose.Schema;
 
 const TaskSchema = new Schema({
+  _id: { type: Schema.Types.ObjectId, required: true },
   user: { type: String, required: true },
   projectId: { type: String, required: true, ref: 'Project' },
   type: {

--- a/src/api/db/schemas/shared/index.ts
+++ b/src/api/db/schemas/shared/index.ts
@@ -7,6 +7,7 @@ const PointSchema = new Schema({
 });
 
 const LocationSchema = new Schema({
+  _id: { type: Schema.Types.ObjectId, required: true },
   geometry: { type: PointSchema, required: true },
   altitude: { type: String },
   name: { type: String },
@@ -32,6 +33,7 @@ const ValidationSchema = new Schema({
  */
 
 const LabelSchema = new Schema({
+  _id: { type: mongoose.Schema.Types.ObjectId, required: true },
   type: { type: String, enum: ['manual', 'ml', 'default'], required: true, default: 'manual' },
   labelId: { type: String, required: true },
   conf: { type: Number },
@@ -53,6 +55,7 @@ const LabelSchema = new Schema({
  */
 
 const ObjectSchema = new Schema({
+  _id: { type: Schema.Types.ObjectId, required: true },
   bbox: { type: [Number], required: true },
   locked: { type: Boolean, default: false, required: true },
   labels: { type: [LabelSchema] },


### PR DESCRIPTION
As discussed in https://github.com/tnc-ca-geo/animl-api/issues/221#issuecomment-2187345858, there are times where Mongoose's TS support falls down.  One of those is the handling of `_id` properties on hydrated subdocuments (see https://github.com/Automattic/mongoose/issues/14660). We can avoid this issue by manually adding the `_id` to each subdocument schema.  This should have no impact on how the system interacts with the DB, but that should be verified via manual testing.