### PR TITLE
Fix unregister camera permissions issue

### DIFF
--- a/src/api/db/models/Camera.ts
+++ b/src/api/db/models/Camera.ts
@@ -7,7 +7,7 @@ import { ProjectModel } from './Project.js';
 import { BaseAuthedModel, MethodParams, roleCheck, idMatch } from './utils.js';
 import { Context } from '../../handler.js';
 import type * as gql from '../../../@types/graphql.js';
-import { ProjectSchema } from '../schemas/Project.js';
+import Project, { ProjectSchema } from '../schemas/Project.js';
 
 const ObjectId = mongoose.Types.ObjectId;
 
@@ -188,6 +188,7 @@ export class CameraModel {
       if (defaultProjReg) defaultProjReg.active = true;
       else {
         cam.projRegistrations.push({
+          _id: new ObjectId(),
           projectId: 'default_project',
           active: true,
         });
@@ -197,7 +198,10 @@ export class CameraModel {
 
       // make sure there's a Project.cameraConfig record for this camera
       // in the default_project and create one if not
-      let [defaultProj] = await ProjectModel.getProjects({ _ids: ['default_project'] }, context);
+      let defaultProj = await Project.findOne({ _id: 'default_project' });
+      if (!defaultProj) {
+        throw new CameraRegistrationError('Could not find default project');
+      }
 
       let addedNewCamConfig = false;
       const camConfig = defaultProj.cameraConfigs.find((cc) => idMatch(cc._id, input.cameraId));

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -173,7 +173,8 @@ export class ProjectModel {
     try {
       return await retry(
         async () => {
-          const [project] = await ProjectModel.getProjects({ _ids: [projectId] }, context);
+          let project = await Project.findOne({ _id: projectId });
+          if (!project) throw new NotFoundError('Project not found');
           console.log('originalProject: ', project);
 
           const newCamConfig = {


### PR DESCRIPTION
When unregistering a camera, sometimes a camera config needs to be created on the `default_project`, and if users don't have access to it the request fails. This PR addresses that.