### PR TITLE
Comments Popover: Add created object ID to createComment mutation

### DIFF
--- a/src/api/db/models/Image.ts
+++ b/src/api/db/models/Image.ts
@@ -459,8 +459,9 @@ export class ImageModel {
       if (!image.comments)
         image.comments = [] as any as mongoose.Types.DocumentArray<ImageCommentSchema>;
       image.comments.push({
+        _id: new ObjectId(),
         author: context.user['cognito:username'],
-        comment: input.comment,
+        comment: input.comment
       });
       await image.save();
 

--- a/src/api/db/models/Image.ts
+++ b/src/api/db/models/Image.ts
@@ -408,7 +408,7 @@ export class ImageModel {
       if (!comment) throw new NotFoundError('Comment not found on image');
 
       if (comment.author !== context.user['cognito:username'] && !context.user['is_superuser']) {
-        throw new ForbiddenError('Can only edit your own comments');
+        throw new ForbiddenError('Can only delete your own comments');
       }
 
       image.comments = image.comments.filter(
@@ -456,12 +456,14 @@ export class ImageModel {
     try {
       const image = await ImageModel.queryById(input.imageId, context);
 
-      if (!image.comments)
+      if (!image.comments) {
         image.comments = [] as any as mongoose.Types.DocumentArray<ImageCommentSchema>;
+      }
+
       image.comments.push({
         _id: new ObjectId(),
         author: context.user['cognito:username'],
-        comment: input.comment
+        comment: input.comment,
       });
       await image.save();
 


### PR DESCRIPTION
**Context**

When creating comments from the [frontend](https://github.com/tnc-ca-geo/animl-frontend/pull/243), the creation fails because an `_id` field is not given when pushing to the comments array.  Fixed by explicitly defining the field and instantiating it using the `new ObjectId()` constructor.

**Related PRs**

- [animl-frontend](https://github.com/tnc-ca-geo/animl-frontend/pull/243)