### PR TITLE
245: add image comments index and image comments filter

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -362,6 +362,7 @@ export type Filters = {
   createdEnd?: Maybe<Scalars['Date']['output']>;
   createdStart?: Maybe<Scalars['Date']['output']>;
   custom?: Maybe<Scalars['String']['output']>;
+  comments?: Maybe<Scalars['String']['output']>;
   deployments?: Maybe<Array<Scalars['String']['output']>>;
   labels?: Maybe<Array<Scalars['String']['output']>>;
   notReviewed?: Maybe<Scalars['Boolean']['output']>;
@@ -375,6 +376,7 @@ export type FiltersInput = {
   createdEnd?: InputMaybe<Scalars['Date']['input']>;
   createdStart?: InputMaybe<Scalars['Date']['input']>;
   custom?: InputMaybe<Scalars['String']['input']>;
+  comments?: InputMaybe<Scalars['String']['input']>;
   deployments?: InputMaybe<Array<Scalars['String']['input']>>;
   labels?: InputMaybe<Array<Scalars['String']['input']>>;
   reviewed?: InputMaybe<Scalars['Boolean']['input']>;

--- a/src/api/db/models/Image.ts
+++ b/src/api/db/models/Image.ts
@@ -124,7 +124,7 @@ export class ImageModel {
           hasNext: false,
         } as AggregationOutput<ImageSchema>;
       }
-      return await MongoPaging.aggregate(Image.collection, {
+      return MongoPaging.aggregate(Image.collection, {
         aggregation: buildPipeline(input.filters, context.user['curr_project']!),
         limit: input.limit,
         paginatedField: input.paginatedField,

--- a/src/api/db/models/utils.ts
+++ b/src/api/db/models/utils.ts
@@ -134,10 +134,21 @@ export function buildPipeline(
     labels,
     reviewed,
     custom,
+    comments
   }: gql.Filters,
   projectId?: string,
 ): PipelineStage[] {
   const pipeline: PipelineStage[] = [];
+
+  if (comments) {
+    pipeline.push({ 
+      $match: {
+        $text: {
+          $search: comments
+        }
+      }
+    })
+  }
 
   // match current project
   if (projectId) {
@@ -199,6 +210,7 @@ export function buildPipeline(
   if (custom) {
     pipeline.push({ $match: isFilterValid(custom) });
   }
+
 
   console.log('utils.buildPipeline() - pipeline: ', JSON.stringify(pipeline));
   return pipeline;

--- a/src/api/db/schemas/Image.ts
+++ b/src/api/db/schemas/Image.ts
@@ -46,6 +46,8 @@ const ImageSchema = new Schema({
 
 ImageSchema.plugin(MongoPaging.mongoosePlugin);
 
+ImageSchema.index({ 'comments.comment': 'text' });
+
 export default mongoose.model('Image', ImageSchema);
 
 export type ImageSchema = mongoose.InferSchemaType<typeof ImageSchema>;

--- a/src/api/type-defs/inputs/QueryImagesInput.ts
+++ b/src/api/type-defs/inputs/QueryImagesInput.ts
@@ -9,6 +9,7 @@ export default /* GraphQL */ `
     labels: [String!]
     reviewed: Boolean
     custom: String
+    comments: String
   }
 
   input QueryImagesInput {

--- a/src/api/type-defs/objects/Filters.ts
+++ b/src/api/type-defs/objects/Filters.ts
@@ -10,5 +10,6 @@ export default /* GraphQL */ `
     reviewed: Boolean
     notReviewed: Boolean
     custom: String
+    comments: String
   }
 `;


### PR DESCRIPTION
**Context**

Implements https://github.com/tnc-ca-geo/animl-frontend/issues/245

Add comments filter so users can filter images by the content of comments on the image.  Implemented using the `$search` `$text` operator in MongoDB.  Note: the `$search` filter needs to be part of the first `$match` of the pipeline.

https://www.mongodb.com/docs/manual/reference/operator/query/text/#mongodb-query-op.-text

**Fixes**
Noticed the LSP was showing a warning that `await` had no effect on `MongoPaging.aggregate` 

**Related PRs**

[animl-frontend](https://github.com/tnc-ca-geo/animl-frontend/pull/246)