### PR TITLE
feat(265): add comments to annotations export in csv

### DIFF
--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -374,12 +374,12 @@ export class AnnotationsExport {
   flattenComments(comments: ImageComment[]): string {
     const serializedComments = comments.map((comment) => {
       // Replace new lines with escaped newlines in output
-      const escapedNewLine = comment.comment.replaceAll('\n', '\\n')
-      return `${comment.author}:${escapedNewLine}`
+      const escapedNewLine = comment.comment.replaceAll('\n', '\\n');
+      return `${comment.author}:${escapedNewLine}`;
     });
     const joinedComments = serializedComments.join(';');
 
-    return joinedComments
+    return joinedComments;
   }
 
   flattenImgTransform(): Transformer {


### PR DESCRIPTION
**Context**

Closes #265 

Adds image comments to csv output as a flattened string column.  Comments are formatted as
```author:comment;author_1:comment_1,...```

New lines in the comment are escaped in the output to avoid new lines in the csv.