### PR TITLE
Async Project Label deletion

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -315,6 +315,7 @@ export type DeleteProjectLabelPayload = {
   __typename?: 'DeleteProjectLabelPayload';
   isOk?: Maybe<Scalars['Boolean']['output']>;
   movingToTask?: Maybe<Scalars['Boolean']['output']>;
+  task?: Maybe<Task>;
 };
 
 export type DeleteProjectTagInput = {

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -308,6 +308,7 @@ export type DeleteObjectsInput = {
 
 export type DeleteProjectLabelInput = {
   _id: Scalars['ID']['input'];
+  ignoreLimit?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type DeleteProjectTagInput = {

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -308,7 +308,13 @@ export type DeleteObjectsInput = {
 
 export type DeleteProjectLabelInput = {
   _id: Scalars['ID']['input'];
-  ignoreLimit?: InputMaybe<Scalars['Boolean']['input']>;
+  processAsTask: Scalars['Boolean']['input'];
+};
+
+export type DeleteProjectLabelPayload = {
+  __typename?: 'DeleteProjectLabelPayload';
+  isOk?: Maybe<Scalars['Boolean']['output']>;
+  movingToTask?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type DeleteProjectTagInput = {
@@ -618,7 +624,7 @@ export type Mutation = {
   deleteImagesTask?: Maybe<Task>;
   deleteLabels?: Maybe<StandardPayload>;
   deleteObjects?: Maybe<StandardPayload>;
-  deleteProjectLabel?: Maybe<StandardPayload>;
+  deleteProjectLabel?: Maybe<DeleteProjectLabelPayload>;
   deleteProjectTag?: Maybe<ProjectTagsPayload>;
   deleteView?: Maybe<DeleteViewPayload>;
   redriveBatch?: Maybe<StandardPayload>;

--- a/src/api/db/models/Image.ts
+++ b/src/api/db/models/Image.ts
@@ -57,7 +57,7 @@ const ObjectId = mongoose.Types.ObjectId;
 // Max number of label remove operations.
 // The lambda will timeout around 30,000 operations.
 // This is a safe limit with a nice number.
-const MAX_LABEL_REMOVE_COUNT = 25000;
+const MAX_LABEL_REMOVE_COUNT = 100; //25000;
 
 export class ImageModel {
   static readonly DELETE_IMAGES_BATCH_SIZE = 300;
@@ -1068,7 +1068,8 @@ export class ImageModel {
   static async deleteLabelsFromImages(
     input: { labelId: string; processAsTask: boolean },
     context: Pick<Context, 'user' | 'config'>,
-  ): Promise<{ isOk: boolean; movingToTask: boolean }> {
+  ): Promise<gql.DeleteProjectLabelPayload> {
+    console.log('ImageModel.deleteLabelsFromImages - input: ', JSON.stringify(input));
     // All images that have at least one object which has the target label
     const allImagesWithLabel = await Image.find({
       projectId: context.user['curr_project']!,
@@ -1184,8 +1185,16 @@ export class ImageModel {
       return { isOk: true, movingToTask: false };
     }
 
+    if (operations.length > MAX_LABEL_REMOVE_COUNT) {
+      console.log('ImageModel.deleteLabelsFromImages - over limit, so moving to task');
+    }
+    if (!input.processAsTask) {
+      console.log('ImageModel.deleteLabelsFromImages - processAsTask is false');
+    }
+
     // if we are over the limit and processAsTask is false, start async task and return early
     if (operations.length > MAX_LABEL_REMOVE_COUNT && !input.processAsTask) {
+      console.log('ImageModel.deleteLabelsFromImages - moving to task');
       try {
         const task = await TaskModel.create(
           {
@@ -1199,15 +1208,21 @@ export class ImageModel {
           },
           context,
         );
+        console.log('ImageModel.deleteLabelsFromImages - task created: ', JSON.stringify(task));
+        return { isOk: true, movingToTask: true, task };
       } catch (err) {
+        console.log('ImageModel.deleteLabelsFromImages - error creating task: ', err);
         return { isOk: false, movingToTask: false };
       }
-      return { isOk: true, movingToTask: true };
     }
 
     // else if it's over the limit and processAsTask is true,
     // this has been called by the task, so continue with the operation
     // or it's under the limit, so continue with the operation
+
+    console.log(
+      'ImageModel.deleteLabelsFromImages - we are either under the limit or over the limit but processing as task, so continuing...',
+    );
 
     const res = await Image.bulkWrite(operations);
     if (!res.isOk()) {
@@ -1217,7 +1232,11 @@ export class ImageModel {
       };
     }
 
+    console.log('ImageModel.deleteLabelsFromImages - Image.bulkWrite() res: ', JSON.stringify(res));
+
     await this.updateReviewStatus(imageIds);
+
+    console.log('ImageModel.deleteLabelsFromImages - review status updated');
 
     return {
       isOk: true,

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -811,6 +811,9 @@ export class ProjectModel {
         context,
       );
       if (isOverLimit) {
+        // TODO: create an async task to delete the labels from the images,
+        // and instead of throwing an error, return a payload with isOverLimit set to true
+        // so that the frontend can start polling for
         const msg =
           'This label is in extensive use and cannot be automatically deleted. Please contact nathaniel[dot]rindlaub@tnc[dot]org to request that it be manually deleted.';
         throw new DeleteLabelError(msg);

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -806,19 +806,14 @@ export class ProjectModel {
       const label = project.labels?.find((p) => p._id.toString() === labelId.toString());
       if (!label) throw new DeleteLabelError('Label not found on project');
 
-      const { isOk, movingToTask } = await ImageModel.deleteLabelsFromImages(
+      const { isOk, movingToTask, task } = await ImageModel.deleteLabelsFromImages(
         { labelId, processAsTask },
         context,
       );
 
       if (movingToTask || !isOk) {
-        // TODO: create an async task to delete the labels from the images,
-        // and instead of throwing an error, return a payload with isOverLimit set to true
-        // so that the frontend can start polling for
-        // const msg =
-        //   'This label is in extensive use and cannot be automatically deleted. Please contact nathaniel[dot]rindlaub@tnc[dot]org to request that it be manually deleted.';
-        // throw new DeleteLabelError(msg);
-        return { isOk, movingToTask };
+        // let the frontend know if we are moving images to a task
+        return { isOk, movingToTask, task };
       }
 
       project.labels.splice(project.labels.indexOf(label), 1);

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -812,7 +812,8 @@ export class ProjectModel {
       );
 
       if (movingToTask || !isOk) {
-        // let the frontend know if we are moving images to a task
+        // let the frontend know that the label deletion is being handled by a Task,
+        // so return the Task ID so that it can poll for progress
         return { isOk, movingToTask, task };
       }
 

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -797,17 +797,20 @@ export class ProjectModel {
   }
 
   static async deleteLabel(
-    input: gql.DeleteProjectLabelInput,
+    { _id: labelId, ignoreLimit = false }: gql.DeleteProjectLabelInput,
     context: Pick<Context, 'user'>,
   ): Promise<gql.StandardPayload> {
     try {
+      console.log('Project.deleteLabel - labelId: ', labelId);
+      console.log('Project.deleteLabel - ignoreLimit: ', ignoreLimit);
+
       const project = await this.queryById(context.user['curr_project']!);
 
-      const label = project.labels?.find((p) => p._id.toString() === input._id.toString());
+      const label = project.labels?.find((p) => p._id.toString() === labelId.toString());
       if (!label) throw new DeleteLabelError('Label not found on project');
 
       const { isOk, isOverLimit } = await ImageModel.deleteLabelsFromImages(
-        { labelId: input._id },
+        { labelId: labelId },
         context,
       );
       if (isOverLimit) {

--- a/src/api/db/schemas/Task.ts
+++ b/src/api/db/schemas/Task.ts
@@ -21,6 +21,7 @@ const TaskSchema = new Schema({
       'DeleteImages',
       'DeleteImagesByFilter',
       'DeleteCamera',
+      'DeleteProjectLabel',
     ],
   },
   status: {

--- a/src/api/resolvers/Mutation.ts
+++ b/src/api/resolvers/Mutation.ts
@@ -267,7 +267,7 @@ export default {
     _: unknown,
     { input }: gql.MutationDeleteProjectLabelArgs,
     context: Context,
-  ): Promise<gql.StandardPayload> => {
+  ): Promise<gql.DeleteProjectLabelPayload> => {
     return context.models.Project.deleteLabel(input, context);
   },
 

--- a/src/api/type-defs/inputs/DeleteProjectLabelInput.ts
+++ b/src/api/type-defs/inputs/DeleteProjectLabelInput.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
   input DeleteProjectLabelInput {
     _id: ID!
+    ignoreLimit: Boolean
   }
 `;

--- a/src/api/type-defs/inputs/DeleteProjectLabelInput.ts
+++ b/src/api/type-defs/inputs/DeleteProjectLabelInput.ts
@@ -1,6 +1,6 @@
 export default /* GraphQL */ `
   input DeleteProjectLabelInput {
     _id: ID!
-    ignoreLimit: Boolean
+    processAsTask: Boolean!
   }
 `;

--- a/src/api/type-defs/payloads/DeleteProjectLabelPayload.ts
+++ b/src/api/type-defs/payloads/DeleteProjectLabelPayload.ts
@@ -2,5 +2,6 @@ export default /* GraphQL */ `
   type DeleteProjectLabelPayload {
     isOk: Boolean
     movingToTask: Boolean
+    task: Task
   }
 `;

--- a/src/api/type-defs/payloads/DeleteProjectLabelPayload.ts
+++ b/src/api/type-defs/payloads/DeleteProjectLabelPayload.ts
@@ -1,0 +1,6 @@
+export default /* GraphQL */ `
+  type DeleteProjectLabelPayload {
+    isOk: Boolean
+    movingToTask: Boolean
+  }
+`;

--- a/src/api/type-defs/root/Mutation.ts
+++ b/src/api/type-defs/root/Mutation.ts
@@ -25,7 +25,7 @@ export default /* GraphQL */ `
 
     createProjectLabel(input: CreateProjectLabelInput!): ProjectLabelPayload
     updateProjectLabel(input: UpdateProjectLabelInput!): ProjectLabelPayload
-    deleteProjectLabel(input: DeleteProjectLabelInput!): StandardPayload
+    deleteProjectLabel(input: DeleteProjectLabelInput!): DeleteProjectLabelPayload
 
     createProjectTag(input: CreateProjectTagInput!): ProjectTagsPayload
     deleteProjectTag(input: DeleteProjectTagInput!): ProjectTagsPayload

--- a/src/task/handler.ts
+++ b/src/task/handler.ts
@@ -51,7 +51,7 @@ async function handler(event: SQSEvent) {
       } else if (task.type === 'DeleteCamera') {
         output = await DeleteCamera(task);
       } else if (task.type === 'DeleteProjectLabel') {
-        output = await DeleteProjectLabel(task);
+        output = await DeleteProjectLabel(task, config);
       } else {
         throw new Error(`Unknown Task: ${JSON.stringify(task)}`);
       }

--- a/src/task/handler.ts
+++ b/src/task/handler.ts
@@ -12,6 +12,7 @@ import { type TaskInput } from '../api/db/models/Task.js';
 import GraphQLError, { InternalServerError } from '../api/errors.js';
 import { type User } from '../api/auth/authorization.js';
 import { DeleteImages, DeleteImagesByFilter } from './image.js';
+import { DeleteProjectLabel } from './project.js';
 
 async function handler(event: SQSEvent) {
   if (!event.Records || !event.Records.length) return;
@@ -49,6 +50,8 @@ async function handler(event: SQSEvent) {
         output = await DeleteImagesByFilter(task);
       } else if (task.type === 'DeleteCamera') {
         output = await DeleteCamera(task);
+      } else if (task.type === 'DeleteProjectLabel') {
+        output = await DeleteProjectLabel(task);
       } else {
         throw new Error(`Unknown Task: ${JSON.stringify(task)}`);
       }

--- a/src/task/project.ts
+++ b/src/task/project.ts
@@ -1,0 +1,9 @@
+import { type User } from '../api/auth/authorization.js';
+import { ProjectModel } from '../api/db/models/Project.js';
+import { type TaskInput } from '../api/db/models/Task.js';
+import type * as gql from '../@types/graphql.js';
+
+export async function DeleteProjectLabel(task: TaskInput<gql.DeleteProjectLabelInput>) {
+  const context = { user: { is_superuser: true, curr_project: task.projectId } as User };
+  return await ProjectModel.deleteLabel(task.config, context);
+}

--- a/src/task/project.ts
+++ b/src/task/project.ts
@@ -1,9 +1,17 @@
 import { type User } from '../api/auth/authorization.js';
 import { ProjectModel } from '../api/db/models/Project.js';
 import { type TaskInput } from '../api/db/models/Task.js';
+import { type Config } from '../config/config.js';
+import { Context } from '../api/handler.js';
 import type * as gql from '../@types/graphql.js';
 
-export async function DeleteProjectLabel(task: TaskInput<gql.DeleteProjectLabelInput>) {
-  const context = { user: { is_superuser: true, curr_project: task.projectId } as User };
+export async function DeleteProjectLabel(
+  task: TaskInput<gql.DeleteProjectLabelInput>,
+  config: Config,
+) {
+  const context = {
+    user: { is_superuser: true, curr_project: task.projectId },
+    config,
+  } as Pick<Context, 'user' | 'config'>;
   return await ProjectModel.deleteLabel(task.config, context);
 }

--- a/test/image#deleteLabels.test.js
+++ b/test/image#deleteLabels.test.js
@@ -34,7 +34,7 @@ tape('Image: DeleteLabel', async (t) => {
       { user: { curr_project: 'mock-project' } },
     );
     t.assert(bulkWriteMock.notCalled);
-    t.assert(noActionRes.isOverLimit === false);
+    t.assert(noActionRes.movingToTask === false);
     t.assert(noActionRes.isOk === true);
 
     // Do nothing
@@ -62,7 +62,7 @@ tape('Image: DeleteLabel', async (t) => {
     );
     t.assert(bulkWriteMock.notCalled);
     t.assert(labelsButNoAction.isOk === true);
-    t.assert(labelsButNoAction.isOverLimit === false);
+    t.assert(labelsButNoAction.movingToTask === false);
 
     // Delete object
     mockFind.reset();
@@ -106,7 +106,7 @@ tape('Image: DeleteLabel', async (t) => {
         },
       ]),
     );
-    t.assert(deleteObjRes.isOverLimit === false);
+    t.assert(deleteObjRes.movingToTask === false);
     t.assert(deleteObjRes.isOk === true);
 
     // Unlock
@@ -160,7 +160,7 @@ tape('Image: DeleteLabel', async (t) => {
       ]),
     );
     t.assert(removeLabelsRes.isOk === true);
-    t.assert(removeLabelsRes.isOverLimit === false);
+    t.assert(removeLabelsRes.movingToTask === false);
 
     // Remove but don't unlock
     mockFind.reset();
@@ -212,7 +212,7 @@ tape('Image: DeleteLabel', async (t) => {
       ]),
     );
     t.assert(removeButDontUnlockRes.isOk === true);
-    t.assert(removeButDontUnlockRes.isOverLimit === false);
+    t.assert(removeButDontUnlockRes.movingToTask === false);
 
     // Do all operations
     mockFind.reset();
@@ -310,7 +310,7 @@ tape('Image: DeleteLabel', async (t) => {
       ]),
     );
     t.assert(doAllRes.isOk === true);
-    t.assert(doAllRes.isOverLimit === false);
+    t.assert(doAllRes.movingToTask === false);
   } catch (err) {
     t.error(err);
   }


### PR DESCRIPTION
**Context**

When deleting a Project Label, if the Project has more than 25k instances of that Label applied to images, move the processing to the async Task lambda to avoid timeouts. 

Closes #285 