### PR TITLE
[308] Add onlyIncludeReviewed option to annotations logic

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -374,6 +374,7 @@ export type ExportInput = {
   filters: FiltersInput;
   format: Format;
   timezone: Scalars['String']['input'];
+  onlyIncludeReviewed?: boolean;
 };
 
 export type ExportPayload = {

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -373,8 +373,8 @@ export type ExportErrorsInput = {
 export type ExportInput = {
   filters: FiltersInput;
   format: Format;
+  onlyIncludeReviewed?: InputMaybe<Scalars['Boolean']['input']>;
   timezone: Scalars['String']['input'];
-  onlyIncludeReviewed?: boolean;
 };
 
 export type ExportPayload = {

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -373,7 +373,7 @@ export type ExportErrorsInput = {
 export type ExportInput = {
   filters: FiltersInput;
   format: Format;
-  onlyIncludeReviewed?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyIncludeReviewed: Scalars['Boolean']['input'];
   timezone: Scalars['String']['input'];
 };
 

--- a/src/api/type-defs/inputs/ExportInput.ts
+++ b/src/api/type-defs/inputs/ExportInput.ts
@@ -8,6 +8,6 @@ export default /* GraphQL */ `
     format: Format!
     timezone: String!
     filters: FiltersInput!
-    onlyIncludeReviewed: Boolean
+    onlyIncludeReviewed: Boolean!
   }
 `;

--- a/src/api/type-defs/inputs/ExportInput.ts
+++ b/src/api/type-defs/inputs/ExportInput.ts
@@ -8,5 +8,6 @@ export default /* GraphQL */ `
     format: Format!
     timezone: String!
     filters: FiltersInput!
+    onlyIncludeReviewed: Boolean
   }
 `;

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -102,6 +102,7 @@ export class AnnotationsExport {
       }
 
       this.pipeline = buildPipeline(sanitizedFilters, this.projectId);
+      this.imageCount = await this.getCount(this.pipeline);
 
       const [project] = await ProjectModel.getProjects(
         { _ids: [this.projectId] },
@@ -467,7 +468,7 @@ export class AnnotationsExport {
   findFirstValidLabel(obj: ObjectSchema): LabelSchema | null {
     return obj.labels.find((label) => label.validation && label.validation.validated) || null;
   }
-  
+
   findRepresentativeLabel(obj: ObjectSchema): LabelSchema | null {
     // if object is locked and has at least one validated label, return the first validated label in the labels array
     // if include reviewed & non-reviewed and the object is unlocked, return the first non-invalidated label in the array
@@ -475,7 +476,7 @@ export class AnnotationsExport {
     if (obj.locked) {
       representativeLabel = this.findFirstValidLabel(obj); // return locked object's first label that is validated
     } else {
-      representativeLabel = obj.labels?.[0] || null // return first label (most recent label added) in list
+      representativeLabel = obj.labels?.[0] || null; // return first label (most recent label added) in list
     }
     return representativeLabel;
   }
@@ -604,7 +605,12 @@ export class AnnotationsExport {
 }
 
 export default async function (
-  task: TaskInput<{ filters: FiltersSchema; format: any; timezone: string; onlyIncludeReviewed: boolean }> & { _id: string },
+  task: TaskInput<{
+    filters: FiltersSchema;
+    format: any;
+    timezone: string;
+    onlyIncludeReviewed: boolean;
+  }> & { _id: string },
   config: Config,
 ): Promise<AnnotationOutput> {
   const dataExport = new AnnotationsExport(
@@ -614,7 +620,7 @@ export default async function (
       filters: task.config.filters,
       format: task.config.format,
       timezone: task.config.timezone,
-      onlyIncludeReviewed: task.config.onlyIncludeReviewed
+      onlyIncludeReviewed: task.config.onlyIncludeReviewed,
     },
     config,
   );

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -263,14 +263,10 @@ export class AnnotationsExport {
       imgString = i === this.imageCount ? imgString : imgString + ', ';
       imagesUpload.streamToS3.write(imgString);
 
-      let objectsToAnnotate = [];
-
       // create COCO annotation record, write to upload stream
-      if (this.onlyIncludeReviewed) {
-        objectsToAnnotate = this.getReviewedObjects(img);
-      } else {
-        objectsToAnnotate = img.objects;
-      }
+      const objectsToAnnotate = this.onlyIncludeReviewed
+        ? this.getReviewedObjects(img)
+        : img.objects;
 
       for (const [o, obj] of objectsToAnnotate.entries()) {
         const annoObj = this.createCOCOAnnotation(obj, img, catMap);
@@ -355,14 +351,9 @@ export class AnnotationsExport {
       imagesArray.push(imgObj);
 
       // create COCO annotation record, add to in-memory array
-      let objectsToAnnotate = [];
-
-      // create COCO annotation record, write to upload stream
-      if (this.onlyIncludeReviewed) {
-        objectsToAnnotate = this.getReviewedObjects(img);
-      } else {
-        objectsToAnnotate = img.objects;
-      }
+      const objectsToAnnotate = this.onlyIncludeReviewed
+        ? this.getReviewedObjects(img)
+        : img.objects;
 
       for (const obj of objectsToAnnotate) {
         const annoObj = this.createCOCOAnnotation(obj, img, catMap);
@@ -434,9 +425,9 @@ export class AnnotationsExport {
 
       this.categories!.forEach((cat) => (catCounts[cat] = null));
       for (const obj of img.objects) {
-        const firstValidLabel = this.findRepresentativeLabel(obj); // The most representative label only applies to objects who have been reviewed/locked
-        if (firstValidLabel) {
-          const cat = this.labelMap!.get(firstValidLabel.labelId).name;
+        const representativeLabel = this.findRepresentativeLabel(obj);
+        if (representativeLabel) {
+          const cat = this.labelMap!.get(representativeLabel.labelId).name;
           catCounts[cat] = catCounts[cat] ? catCounts[cat] + 1 : 1;
         }
       }

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -295,7 +295,7 @@ export class AnnotationsExport {
     const res = await Promise.allSettled([imagesUpload.promise, annotationsUpload.promise]);
     console.log('finished uploading all the parts: ', res);
 
-    // concatonate images and annotations .json files via multipart upload copy part
+    // concatenate images and annotations .json files via multipart upload copy part
     const initResponse = await this.s3.send(
       new S3.CreateMultipartUploadCommand({
         Key: this.filename,
@@ -576,21 +576,24 @@ export class AnnotationsExport {
         category_id?: number;
         sequence_level_annotation: boolean;
         bbox: number[];
+        confidence: number | null | undefined;
       }
     | undefined {
     let anno;
-    const firstValidLabel = this.findRepresentativeLabel(object);
-    if (firstValidLabel) {
+    const representativeLabel = this.findRepresentativeLabel(object);
+    if (representativeLabel) {
       const category = catMap.find(
-        (cat) => cat.name === this.labelMap!.get(firstValidLabel.labelId).name,
+        (cat) => cat.name === this.labelMap!.get(representativeLabel.labelId).name,
       );
-      if (!category) throw new InternalServerError('Error finding category for first valid label');
+      if (!category)
+        throw new InternalServerError('Error finding category for representative label');
       anno = {
         id: object._id, // id copied from the object, not the label
         image_id: img._id,
         category_id: category.id,
         sequence_level_annotation: false,
         bbox: this.relToAbs(object.bbox, img.imageWidth!, img.imageHeight!),
+        confidence: representativeLabel.conf,
       };
     }
     return anno;

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -568,6 +568,7 @@ export class AnnotationsExport {
         sequence_level_annotation: boolean;
         bbox: number[];
         confidence: number | null | undefined;
+        validated: boolean;
       }
     | undefined {
     let anno;
@@ -585,6 +586,7 @@ export class AnnotationsExport {
         sequence_level_annotation: false,
         bbox: this.relToAbs(object.bbox, img.imageWidth!, img.imageHeight!),
         confidence: representativeLabel.conf,
+        validated: representativeLabel.validation?.validated || false,
       };
     }
     return anno;

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -88,7 +88,6 @@ export class AnnotationsExport {
         { ...sanitizedFilters, reviewed: false },
         this.projectId,
       );
-
       const reviewedPipeline = buildPipeline(
         { ...sanitizedFilters, reviewed: true },
         this.projectId,
@@ -466,7 +465,13 @@ export class AnnotationsExport {
   }
 
   findFirstValidLabel(obj: ObjectSchema): LabelSchema | null {
+    // label has validation and is validated true
     return obj.labels.find((label) => label.validation && label.validation.validated) || null;
+  }
+
+  findFirstNonInvalidatedLabel(obj: ObjectSchema): LabelSchema | null {
+    // label either has no validation or is validated true
+    return obj.labels.find((label) => !label.validation || label.validation.validated) || null;
   }
 
   findRepresentativeLabel(obj: ObjectSchema): LabelSchema | null {
@@ -474,9 +479,11 @@ export class AnnotationsExport {
     // if include reviewed & non-reviewed and the object is unlocked, return the first non-invalidated label in the array
     let representativeLabel = null;
     if (obj.locked) {
-      representativeLabel = this.findFirstValidLabel(obj); // return locked object's first label that is validated
+      // return locked object's first label that is validated
+      representativeLabel = this.findFirstValidLabel(obj);
     } else {
-      representativeLabel = obj.labels?.[0] || null; // return first label (most recent label added) in list
+      // return first label (most recent label added) in list that hasn't been invalidated
+      representativeLabel = this.findFirstNonInvalidatedLabel(obj) || null;
     }
     return representativeLabel;
   }

--- a/src/task/annotations.ts
+++ b/src/task/annotations.ts
@@ -31,7 +31,7 @@ export class AnnotationsExport {
   ext: string;
   filename: string;
   bucket: string;
-  onlyIncludeReviewed?: boolean;
+  onlyIncludeReviewed: boolean;
   presignedURL: string | null;
   imageCount: number;
   imageCountThreshold: number;
@@ -57,7 +57,7 @@ export class AnnotationsExport {
       filters: FiltersSchema;
       format: string;
       timezone: string;
-      onlyIncludeReviewed?: boolean;
+      onlyIncludeReviewed: boolean;
     },
     config: Config,
   ) {
@@ -72,7 +72,7 @@ export class AnnotationsExport {
     this.ext = format === 'coco' ? '.json' : '.csv';
     this.filename = `${documentId}_${format}${this.ext}`;
     this.bucket = config['/EXPORTS/EXPORTED_DATA_BUCKET'];
-    this.onlyIncludeReviewed = onlyIncludeReviewed; // TODO: move into config or expose as option?
+    this.onlyIncludeReviewed = onlyIncludeReviewed;
     this.presignedURL = null;
     this.imageCount = 0;
     this.imageCountThreshold = 18000; // TODO: Move to config?
@@ -604,7 +604,7 @@ export class AnnotationsExport {
 }
 
 export default async function (
-  task: TaskInput<{ filters: FiltersSchema; format: any; timezone: string; onlyIncludeReviewed?: boolean }> & { _id: string },
+  task: TaskInput<{ filters: FiltersSchema; format: any; timezone: string; onlyIncludeReviewed: boolean }> & { _id: string },
   config: Config,
 ): Promise<AnnotationOutput> {
   const dataExport = new AnnotationsExport(

--- a/src/task/handler.ts
+++ b/src/task/handler.ts
@@ -20,7 +20,6 @@ async function handler(event: SQSEvent) {
   await connectToDatabase(config);
 
   for (const record of event.Records) {
-    console.log(`record body: ${record.body}`);
     const task: TaskInput<any> & { _id: string } = parseMessage(JSON.parse(record.body));
 
     let output: Record<any, any> | undefined = {};
@@ -28,7 +27,7 @@ async function handler(event: SQSEvent) {
       { _id: task._id, status: 'RUNNING' },
       { user: { curr_project: task.projectId } as User },
     );
-    console.log('TaskModel task.type:', task.type);
+  
     try {
       if (task.type === 'GetStats') {
         output = await GetStats(task);

--- a/src/task/stats.ts
+++ b/src/task/stats.ts
@@ -69,7 +69,7 @@ export default async function (
     reviewedCount: { reviewed, notReviewed },
     reviewerList,
     labelList,
-    multiReviewerCount,
+    multiReviewerCount
   };
 }
 


### PR DESCRIPTION
Ticket: https://github.com/tnc-ca-geo/animl-api/issues/308
Related PRs: https://github.com/tnc-ca-geo/animl-frontend/pull/299

These changes add the `onlyIncludeReviewed` param to the annotations logic.

Self Validation / Demo Locally:
https://www.loom.com/share/242b7d3baecb4b1baa8a855fd286404f?sid=67c61de7-6f70-48a8-af7e-f498796a27d7