### PR TITLE
Burst stats

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1123,8 +1123,15 @@ export type QueryProjectsInput = {
   _ids?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export enum AggregationLevel {
+  imageAndObject = "imageAndObject",
+  burst = "burst",
+  independentDetection = "independentDetection",
+}
+
 export type QueryStatsInput = {
   filters: FiltersInput;
+  aggregationLevel?: AggregationLevel
 };
 
 export type QueryTaskInput = {

--- a/src/api/type-defs/inputs/QueryStatsInput.ts
+++ b/src/api/type-defs/inputs/QueryStatsInput.ts
@@ -1,5 +1,12 @@
 export default /* GraphQL */ `
+  enum AggregationLevel {
+    imageAndObject
+    burst
+    independentDetection
+  }
+
   input QueryStatsInput {
     filters: FiltersInput!
+    aggregationLevel: AggregationLevel!
   }
 `;

--- a/src/task/getBursts.ts
+++ b/src/task/getBursts.ts
@@ -1,0 +1,107 @@
+import _ from 'lodash';
+import { DateTime } from 'luxon';
+
+import { ProjectModel } from '../api/db/models/Project.js';
+import { buildPipeline, idMatch } from '../api/db/models/utils.js';
+import { findRepresentativeLabel } from './utils.js';
+import { TaskInput } from '../api/db/models/Task.js';
+import { CameraConfigSchema, DeploymentSchema, FiltersSchema } from '../api/db/schemas/Project.js';
+import { AggregationLevel } from '../@types/graphql.js';
+import Image, { ImageSchema } from '../api/db/schemas/Image.js';
+
+
+const MAX_SEQUENCE_DELTA = 2;
+
+type Task = TaskInput<{ filters: FiltersSchema, aggregationLevel: AggregationLevel }>
+export type BurstsTask = TaskInput<{ filters: FiltersSchema, aggregationLevel: AggregationLevel.burst }>;
+export interface GetBurstOutput {
+  burstCount: number;
+  burstLabelList: Record<string, number>;
+}
+
+export default async function getBurstStats(task: Task): Promise<GetBurstOutput> {
+  const context = { user: { is_superuser: true, curr_project: task.projectId } };
+  const project = await ProjectModel.queryById(context.user['curr_project']);
+  const pipeline = buildPipeline(task.config.filters, context.user['curr_project']);
+
+  const cameraConfigs = project.cameraConfigs;
+  const deployments: Array<DeploymentSchema> = cameraConfigs.reduce(
+    (
+      deps: Array<DeploymentSchema>,
+      config: CameraConfigSchema
+    ) => {
+      return [...deps, ...config.deployments];
+    },
+    []
+  );
+
+  let burstCount = 0;
+  const burstLabelList: Record<string, number> = {};
+
+  const processBurst = (sequence: ImageSchema[]) => {
+    burstCount++;
+
+    const sequenceLabels: string[] = [];
+
+    for (const img of sequence) {
+      for (const obj of img.objects) {
+        const representativeLabel = findRepresentativeLabel(obj);
+        if (representativeLabel) {
+          const projLabel = project.labels.find((lbl) => idMatch(lbl._id, representativeLabel.labelId));
+          const labelName = projLabel?.name || 'ERROR FINDING LABEL';
+          if (!sequenceLabels.includes(labelName)) {
+            sequenceLabels.push(labelName);
+          }
+        }
+      }
+    }
+
+    for (const label of sequenceLabels) {
+      burstLabelList[label] = Object.prototype.hasOwnProperty.call(burstLabelList, label)
+        ? burstLabelList[label] + 1
+        : 1;
+    }
+  };
+
+  for (const dep of deployments) {
+    const depPipeline = structuredClone(pipeline);
+    depPipeline.push({
+      $match:{
+        deploymentId: dep._id,
+      }
+    });
+
+    let sequence: ImageSchema[] = [];
+
+    for await (const img of Image.aggregate(depPipeline)) {
+      if (sequence.length === 0) {
+        sequence.push(img);
+        continue;
+      }
+
+      const lastImg = sequence[sequence.length - 1];
+      const imgDateAdded = DateTime.fromJSDate(img.dateTimeOriginal);
+      const lastImgDateAdded = DateTime.fromJSDate(lastImg.dateTimeOriginal);
+      const diff = lastImgDateAdded.diff(imgDateAdded, 'seconds').toObject();
+      const delta = Math.abs(diff.seconds || 0);
+
+      // if the delta between the last image and the current image is less than the max sequence delta,
+      if (delta <= MAX_SEQUENCE_DELTA) {
+        // image belongs to current sequence
+        sequence.push(img);
+      } else {
+        // found a gap,
+        processBurst(sequence);
+        sequence = [img];
+      }
+    }
+    if (sequence.length > 0) {
+      processBurst(sequence);
+    }
+  }
+
+  return {
+    burstCount,
+    burstLabelList
+  };
+}

--- a/src/task/stats.ts
+++ b/src/task/stats.ts
@@ -5,10 +5,40 @@ import _ from 'lodash';
 import { type TaskInput } from '../api/db/models/Task.js';
 import { type FiltersSchema } from '../api/db/schemas/Project.js';
 import { findRepresentativeLabel } from './utils.js';
+import { AggregationLevel } from '../@types/graphql.js';
+import getBurstStats, { BurstsTask, GetBurstOutput } from './getBursts.js';
 
-export default async function (
-  task: TaskInput<{ filters: FiltersSchema }>,
-): Promise<GetStatsOutput> {
+type Task = TaskInput<{ filters: FiltersSchema, aggregationLevel: AggregationLevel }>
+type ImageAndObjectsTask = TaskInput<{ filters: FiltersSchema, aggregationLevel: AggregationLevel.imageAndObject }>;
+
+interface Reviewer {
+  userId: string;
+  reviewedCount: number;
+}
+
+interface ReviewCount {
+  reviewed: number;
+  notReviewed: number;
+}
+
+interface GetStatsOutput {
+  imageCount: number;
+  imageReviewCount: ReviewCount;
+  objectCount: number;
+  objectReviewCount: ReviewCount;
+  imageReviewerList: Reviewer[];
+  objectReviewerList: Reviewer[];
+  objectLabelList: Record<string, number>;
+  imageLabelList: Record<string, number>;
+  multiReviewerCount: number;
+}
+
+type Return<T extends Task> =
+  T extends ImageAndObjectsTask ? GetStatsOutput :
+  T extends BurstsTask ? GetBurstOutput :
+  GetStatsOutput;
+
+async function getImageAndObjectStats(task: Task): Promise<GetStatsOutput> {
   const context = { user: { is_superuser: true, curr_project: task.projectId } };
   let imageCount = 0;
   let imagesReviewed = 0;
@@ -107,19 +137,16 @@ export default async function (
   };
 }
 
-interface GetStatsOutput {
-  imageCount: number;
-  imageReviewCount: { reviewed: number; notReviewed: number };
-  objectCount: number;
-  objectReviewCount: { reviewed: number; notReviewed: number };
-  imageReviewerList: Reviewer[];
-  objectReviewerList: Reviewer[];
-  objectLabelList: Record<string, number>;
-  imageLabelList: Record<string, number>;
-  multiReviewerCount: number;
-}
+export default async function<T extends Task> (task: T): Promise<Return<T>> {
+  switch(task.config.aggregationLevel) {
+    case AggregationLevel.imageAndObject:
+      return getImageAndObjectStats(task) as Promise<Return<T>>;
+    case AggregationLevel.burst:
+      return getBurstStats(task) as Promise<Return<T>>;
+    case AggregationLevel.independentDetection:
+      // TODO independent detections
+      break;
+    }
 
-interface Reviewer {
-  userId: string;
-  reviewedCount: number;
+  return getImageAndObjectStats(task) as Promise<Return<T>>;
 }

--- a/src/task/stats.ts
+++ b/src/task/stats.ts
@@ -66,7 +66,10 @@ export default async function (
     // build label list
     const imageLabels: string[] = [];
     for (const obj of img.objects) {
-      objectCount++;
+      if (obj.labels.some(label => label.validation && label.validation.validated)) {
+        // exlude objects where all labels are invalidated
+        objectCount++;
+      }
       obj.locked ? objectsReviewed++ : objectsNotReviewed++;
 
       const representativeLabel = findRepresentativeLabel(obj);


### PR DESCRIPTION
Adds bursts stats to the API

This uses the `GetStats`, and to differentiate between image/object stats and bursts stats, we're introducing `AggregationLevel` to the `QueryStatsInput`. 