### PR TITLE
fix: Alerts images should have proper expiration

### DIFF
--- a/src/automation/alerts.js
+++ b/src/automation/alerts.js
@@ -16,8 +16,7 @@ const makeEmail = async (rule, image, context) => {
     const projId = image.projectId;
     const [project] = await context.models.Project.getProjects({ _ids: [projId] }, context);
     const frontendUrl = await buildFrontendUrl(image, project, context.config);
-    const ttlYears = 50;
-    const imageUrl = buildImgUrl(image, context.config, 'medium', ttlYears * 365 * 24 * 60);
+    const imageUrl = buildImgUrl(image, context.config, 'medium', 50);
 
     let deployment;
     for (const camConfig of project.cameraConfigs) {


### PR DESCRIPTION
In 7841b55, we changed the unit of the buildImgUrl ttl from minutes to years. alerts.js was expecting it to be in minutes. This commit updates the value to be provided in years.