### PR TITLE
Improve typing around buildImgUrl

### DIFF
--- a/src/api/db/models/utils.ts
+++ b/src/api/db/models/utils.ts
@@ -34,18 +34,54 @@ export function buildImgKey(image: ImageSchema, size = 'original'): string {
 export function buildImgUrl(
   image: ImageSchema,
   config: Config,
-  size = 'original',
-  ttlYears = 50,
+  size: keyof gql.SignedImageUrl = 'original',
+  ttl: Duration = Duration.fromWeeks(2),
 ): string {
   const distributionDomain = config['/IMAGES/URL'];
   const privateKey = config[`/IMAGES/CLOUDFRONT_DISTRIBUTION_PRIVATEKEY`];
   const keyPairId = config[`/IMAGES/CLOUDFRONT_PUBLIC_KEY_ID`];
   return getSignedUrl({
     url: `https://${distributionDomain}/${buildImgKey(image, size)}`,
-    dateLessThan: new Date(Date.now() + ttlYears * 365 * 24 * 60 * 60 * 1000),
+    dateLessThan: new Date(Date.now() + ttl.milliseconds),
     keyPairId,
     privateKey,
   });
+}
+
+export class Duration {
+  readonly milliseconds: number;
+
+  private constructor(ms: number) {
+    this.milliseconds = ms;
+  }
+
+  static fromMilliseconds(ms: number): Duration {
+    return new Duration(ms);
+  }
+
+  static fromSeconds(seconds: number): Duration {
+    return new Duration(seconds * 1000);
+  }
+
+  static fromMinutes(minutes: number): Duration {
+    return new Duration(minutes * 60 * 1000);
+  }
+
+  static fromHours(hours: number): Duration {
+    return new Duration(hours * 60 * 60 * 1000);
+  }
+
+  static fromDays(days: number): Duration {
+    return new Duration(days * 24 * 60 * 60 * 1000);
+  }
+
+  static fromWeeks(weeks: number): Duration {
+    return new Duration(weeks * 7 * 24 * 60 * 60 * 1000);
+  }
+
+  static fromYears(years: number): Duration {
+    return new Duration(years * 365.25 * 24 * 60 * 60 * 1000);
+  }
 }
 
 export function buildTagPipeline(tags: string[]): PipelineStage[] {

--- a/src/api/resolvers/Fields.ts
+++ b/src/api/resolvers/Fields.ts
@@ -1,6 +1,7 @@
 import { Context } from '../handler.js';
 import type { ImageSchema } from '../db/schemas/Image.js';
 import { buildImgUrl } from '../db/models/utils.js';
+import type { SignedImageUrl } from '../../@types/graphql.js';
 
 // Field level resolvers
 // NOTE: For more information on resolver chains and when to use field-level resolvers, see:
@@ -10,7 +11,7 @@ export default {
   Image: {
     url: (parent: ImageSchema, _: unknown, context: Context) =>
       Object.fromEntries(
-        ['original', 'medium', 'small'].map((size) => [
+        (['original', 'medium', 'small'] as Array<keyof SignedImageUrl>).map((size) => [
           size,
           buildImgUrl(parent, context.config, size),
         ]),

--- a/src/automation/alerts.js
+++ b/src/automation/alerts.js
@@ -1,6 +1,6 @@
 import { InternalServerError } from '../api/errors.js';
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
-import { buildImgUrl, idMatch } from '../api/db/models/utils.js';
+import { buildImgUrl, Duration, idMatch } from '../api/db/models/utils.js';
 
 const ses = new SESClient({ apiVersion: '2010-12-01' });
 
@@ -16,8 +16,7 @@ const makeEmail = async (rule, image, context) => {
     const projId = image.projectId;
     const [project] = await context.models.Project.getProjects({ _ids: [projId] }, context);
     const frontendUrl = await buildFrontendUrl(image, project, context.config);
-    const ttlYears = 50;
-    const imageUrl = buildImgUrl(image, context.config, 'medium', ttlYears * 365 * 24 * 60);
+    const imageUrl = buildImgUrl(image, context.config, 'medium', Duration.fromYears(50));
 
     let deployment;
     for (const camConfig of project.cameraConfigs) {


### PR DESCRIPTION
* Fix alert image TTL by setting to 50 years (was passing in integer in unit of minutes rather than years)
* Add `Duration` type to avoid future bugs around units of time
* Make buildImgUrl default to 2 weeks
* Add typing for size