### PR TITLE
Add independence interval input param

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1138,6 +1138,7 @@ export type QueryProjectsInput = {
 export type QueryStatsInput = {
   aggregationLevel: AggregationLevel;
   filters: FiltersInput;
+  independenceInterval?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type QueryTaskInput = {

--- a/src/api/type-defs/inputs/QueryStatsInput.ts
+++ b/src/api/type-defs/inputs/QueryStatsInput.ts
@@ -8,5 +8,6 @@ export default /* GraphQL */ `
   input QueryStatsInput {
     filters: FiltersInput!
     aggregationLevel: AggregationLevel!
+    independenceInterval: Int
   }
 `;

--- a/src/task/stats.ts
+++ b/src/task/stats.ts
@@ -12,7 +12,11 @@ import getIndependentDetectionStats, {
   IndependentDetectionsTask,
 } from './getIndependentDetections.js';
 
-type Task = TaskInput<{ filters: FiltersSchema; aggregationLevel: AggregationLevel }>;
+type Task = TaskInput<{
+  filters: FiltersSchema;
+  aggregationLevel: AggregationLevel;
+  independenceInterval: number;
+}>;
 type ImageAndObjectsTask = TaskInput<{
   filters: FiltersSchema;
   aggregationLevel: AggregationLevel.ImageAndObject;


### PR DESCRIPTION
Adds new input parameter for the `GetStats` task allowing to specify the interval length for independent detections. 