### PR TITLE
Compute dateTimeAdjusted in mongo pipeline

### DIFF
--- a/src/api/db/models/utils.ts
+++ b/src/api/db/models/utils.ts
@@ -287,6 +287,19 @@ export function buildPipeline(
     pipeline.push({ $match: isFilterValid(custom) });
   }
 
+  // Mongoose virtuals are not available in aggregations since they are computed in mongo
+  pipeline.push({
+    $addFields: {
+      dateTimeAdjusted: {
+        $cond: {
+          if: { $ifNull: ['$dateTimeOffsetMs', false] },
+          then: { $add: ['$dateTimeOriginal', '$dateTimeOffsetMs'] },
+          else: '$dateTimeOriginal',
+        },
+      },
+    },
+  });
+
   console.log('utils.buildPipeline() - pipeline: ', JSON.stringify(pipeline));
   return pipeline;
 }


### PR DESCRIPTION
Mongoose virtuals are not accessible in the objects returned by mongo aggregations. Add the computation to the pipeline so it's accessible in consumers of this.

fixes issue 363

Test, see the same image exported with both no offset and a -1 hour offset:
<img width="892" height="168" alt="Screenshot 2025-10-21 at 8 46 53 AM" src="https://github.com/user-attachments/assets/5862a1a5-075e-4862-a133-da461dea39d0" />
