### PR TITLE
Disable retention of old Lambda code

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ provider:
   stage: ${opt:stage, 'dev'}
   region: us-west-2
   profile: animl
+  versionFunctions: false
   environment:
     REGION: ${self:provider.region}
     STAGE: ${self:provider.stage}


### PR DESCRIPTION
We ran into the following Serverless error when trying to deploy to prod: `Resource handler returned message: "Code storage limit exceeded. (Service: Lambda, Status Code: 400, Request ID: 5662e905-de58-48a3-bb28-c018897bf1d8) (SDK Attempt Count: 1)"`

[Evidently](https://seed.run/docs/serverless-errors/code-storage-limit-exceeded) Serverless retains old Lambda code by default. This PR disables that behavior.