### PR TITLE
Admin dashboard v2

### DIFF
--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1030,6 +1030,7 @@ export type Project = {
   availableMLModels?: Maybe<Array<Scalars['String']['output']>>;
   cameraConfigs?: Maybe<Array<CameraConfig>>;
   country?: Maybe<Scalars['String']['output']>;
+  created: Scalars['Date']['output'];
   description?: Maybe<Scalars['String']['output']>;
   labels?: Maybe<Array<ProjectLabel>>;
   location?: Maybe<Location>;

--- a/src/@types/graphql.ts
+++ b/src/@types/graphql.ts
@@ -1412,6 +1412,7 @@ export type UpdatePredictionStatusInput = {
 };
 
 export type UpdateProjectInput = {
+  availableMLModels?: InputMaybe<Array<Scalars['String']['input']>>;
   country?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   location?: InputMaybe<LocationInput>;
@@ -1419,6 +1420,7 @@ export type UpdateProjectInput = {
   organization?: InputMaybe<Scalars['String']['input']>;
   stage?: InputMaybe<ProjectStage>;
   state_province?: InputMaybe<Scalars['String']['input']>;
+  timezone?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<ProjectType>;
 };
 

--- a/src/api/db/models/Project.ts
+++ b/src/api/db/models/Project.ts
@@ -155,7 +155,36 @@ export class ProjectModel {
     try {
       const project = await this.queryById(context.user['curr_project']!);
 
-      Object.assign(project, input);
+      // prevent editing of default Project
+      if (project._id === 'default_project') {
+        throw new ForbiddenError('The default project cannot be edited');
+      }
+
+      // timezone and availableMLModels are superuser-only fields
+      if ((input.timezone || input.availableMLModels) && !context.user['is_superuser']) {
+        throw new ForbiddenError('Only superusers can update timezone or availableMLModels');
+      }
+
+      // Merge availableMLModels (union only — models can be added but not removed)
+      if (input.availableMLModels) {
+        const newModels = input.availableMLModels.filter(
+          (m) => !project.availableMLModels.includes(m),
+        );
+        if (newModels.length) {
+          const validModels = (await MLModelModel.getMLModels({ _ids: newModels })).map(
+            (model) => model._id,
+          );
+          for (const m of newModels) {
+            if (!validModels.includes(m))
+              throw new DBValidationError(`${m} is not a valid model identifier`);
+          }
+          project.availableMLModels.push(...newModels);
+        }
+        const { availableMLModels: _, ...rest } = input;
+        Object.assign(project, rest);
+      } else {
+        Object.assign(project, input);
+      }
 
       await project.save();
 

--- a/src/api/db/schemas/Project.ts
+++ b/src/api/db/schemas/Project.ts
@@ -119,6 +119,7 @@ const ProjectSchema = new Schema({
   location: { type: LocationSchema },
   country: { type: String },
   state_province: { type: String },
+  created: { type: Date, required: true, default: Date.now },
 });
 
 export default mongoose.model('Project', ProjectSchema);

--- a/src/api/type-defs/inputs/UpdateProjectInput.ts
+++ b/src/api/type-defs/inputs/UpdateProjectInput.ts
@@ -2,6 +2,8 @@ export default /* GraphQL */ `
   input UpdateProjectInput {
     name: String
     description: String
+    timezone: String
+    availableMLModels: [String!]
     type: ProjectType
     stage: ProjectStage
     organization: String

--- a/src/api/type-defs/objects/Project.ts
+++ b/src/api/type-defs/objects/Project.ts
@@ -55,5 +55,6 @@ export default /* GraphQL */ `
     location: Location
     country: String
     state_province: String
+    created: Date!
   }
 `;

--- a/src/scripts/operations.js
+++ b/src/scripts/operations.js
@@ -491,6 +491,35 @@ const operations = {
       return { nModified: doneCount };
     },
   },
+
+  'backfill-project-created': {
+    getIds: async () => await Project.find({ created: { $exists: false } }).select('_id'),
+    update: async () => {
+      console.log('Backfilling created field on all projects...');
+      const projects = await Project.find({ created: { $exists: false } });
+      try {
+        const res = { nModified: 0 };
+        for (const proj of projects) {
+          let created;
+          const defaultView =
+            proj.views.find((v) => v.name === 'All images');
+          if (defaultView && defaultView._id) {
+            created = defaultView._id.getTimestamp();
+            console.log(`Project ${proj._id}: derived created date ${created} from "All images" view ObjectId`);
+          } else {
+            created = new Date();
+            console.warn(`Project ${proj._id}: no "All images" view found, falling back to current date`);
+          }
+          proj.created = created;
+          await proj.save();
+          res.nModified++;
+        }
+        return res;
+      } catch (err) {
+        console.log(err);
+      }
+    },
+  },
 };
 
 export { operations };

--- a/src/scripts/operations.js
+++ b/src/scripts/operations.js
@@ -80,7 +80,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -113,7 +114,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -142,7 +144,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -185,7 +188,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -219,7 +223,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -260,13 +265,15 @@ const operations = {
           operations.push(op);
         }
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
 
       try {
         return await Image.bulkWrite(operations);
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },
@@ -501,14 +508,17 @@ const operations = {
         const res = { nModified: 0 };
         for (const proj of projects) {
           let created;
-          const defaultView =
-            proj.views.find((v) => v.name === 'All images');
+          const defaultView = proj.views.find((v) => v.name === 'All images');
           if (defaultView && defaultView._id) {
             created = defaultView._id.getTimestamp();
-            console.log(`Project ${proj._id}: derived created date ${created} from "All images" view ObjectId`);
+            console.log(
+              `Project ${proj._id}: derived created date ${created} from "All images" view ObjectId`,
+            );
           } else {
             created = new Date();
-            console.warn(`Project ${proj._id}: no "All images" view found, falling back to current date`);
+            console.warn(
+              `Project ${proj._id}: no "All images" view found, falling back to current date`,
+            );
           }
           proj.created = created;
           await proj.save();
@@ -516,7 +526,8 @@ const operations = {
         }
         return res;
       } catch (err) {
-        console.log(err);
+        console.error(err);
+        throw err;
       }
     },
   },

--- a/src/scripts/updateDocuments.js
+++ b/src/scripts/updateDocuments.js
@@ -44,7 +44,7 @@ async function createLogFile(collecton, _ids, operation) {
 
 async function updateDocuments() {
   // TODO: accept op as param
-  const op = 'COPY-OPERATION-NAME-HERE';
+  const op = 'backfill-project-created'; //'COPY-OPERATION-NAME-HERE';
   const config = await getConfig();
   const dbClient = await connectToDatabase(config);
 

--- a/src/scripts/updateDocuments.js
+++ b/src/scripts/updateDocuments.js
@@ -44,7 +44,7 @@ async function createLogFile(collecton, _ids, operation) {
 
 async function updateDocuments() {
   // TODO: accept op as param
-  const op = 'backfill-project-created'; //'COPY-OPERATION-NAME-HERE';
+  const op = 'COPY-OPERATION-NAME-HERE';
   const config = await getConfig();
   const dbClient = await connectToDatabase(config);
 
@@ -68,7 +68,7 @@ async function updateDocuments() {
       if (res.nModified === matchCount) {
         await createLogFile('images', matchingImageIds, op);
       } else {
-        const msg = `There was a discrepency between the number of matching documents
+        const msg = `There was a discrepancy between the number of matching documents
           and the number of modified documents: ${matchCount} vs ${res.nModified}`;
         throw new InternalServerError(msg);
       }


### PR DESCRIPTION
## Add `created` field to Projects + admin dashboard project editing support

### Summary

Adds a `created` timestamp field to `Project` documents and extends `updateProject` to support editing `timezone` and `availableMLModels` for superusers, in support of an admin dashboard v2.

---

### Changes

#### New `Project.created` field
- Added `created: Date` to the Mongoose `ProjectSchema` with `default: Date.now`, so all new projects automatically record their creation timestamp.
- Exposed `created: Date!` on the `Project` GraphQL type.

#### `updateProject` improvements
- Added protection for the `default_project` — it can no longer be edited via this mutation.
- **Superuser-only**: `timezone` and `availableMLModels` can now be set via `UpdateProjectInput`, but only by superusers. Non-superusers receive a `ForbiddenError`.
- **Additive-only `availableMLModels`**: incoming model IDs are merged (union) with the existing array — models can only be added, never removed, to prevent unexpected downstream consequences. New model IDs are validated against the database before being accepted.

#### Backfill migration
- Added `backfill-project-created` operation to operations.js that derives each existing project's `created` date from the `ObjectId` timestamp of its default "All images" view. Falls back to `new Date()` (with a warning) if no such view is found.

> ⚠️ **Pre-deploy requirement**: The `backfill-project-created` migration must be run against each environment before this deploy. Until it runs, existing project documents lack `created`, and any `save()` on those documents will fail Mongoose's `required` validation.